### PR TITLE
Fix broken links in src/ docs

### DIFF
--- a/src/docs/development.md
+++ b/src/docs/development.md
@@ -1,7 +1,7 @@
 # WindowsDevSetupScripts — Developer Guide
 
 > 👋 **Just want to run something?** See the
-> [top-level README](../README.md). This file is the contributor /
+> [top-level README](../../README.md). This file is the contributor /
 > CI / "how the sausage gets made" guide.
 
 Opinionated, CI-validated configurations for bootstrapping developer

--- a/src/future/cmdpal/README.md
+++ b/src/future/cmdpal/README.md
@@ -2,7 +2,7 @@
 
 A [PowerToys Command Palette](https://learn.microsoft.com/en-us/windows/powertoys/command-palette/overview)
 extension that surfaces the developer flows defined in this repo's
-[`manifest.yml`](../manifest.yml). Pick a flow, hit Enter, and the extension
+[`manifest.yml`](../../manifest.yml). Pick a flow, hit Enter, and the extension
 launches `winget configure` (Windows) or `wsl bash` (Linux) in a new Windows
 Terminal tab — no need to remember which `.winget` file goes with which
 toolchain.
@@ -11,12 +11,12 @@ toolchain.
 
 This extension launches flows exclusively through `winget configure`. If
 that subcommand is not wired up on the host, no Windows flow surfaced by
-CmdPal can succeed. See the
-[top-level README's Prerequisites section](../README.md#prerequisites-windows)
-for the three conditions that must hold (current App Installer, the
+CmdPal can succeed. See the developer guide's
+[`Prerequisites (Windows)`](../../docs/development.md#prerequisites-windows)
+section for the three conditions that must hold (current App Installer, the
 `configuration` feature enabled, and no blocking ADMX policy) and the
 one-line smoke test. The shared preflight
-[`scripts/windows/_common/assert-winget-configure.ps1`](../scripts/windows/_common/assert-winget-configure.ps1)
+[`Workloads/_common/assert-winget-configure.ps1`](../../Workloads/_common/assert-winget-configure.ps1)
 enforces this at runtime with an actionable error message.
 
 ## Source of truth
@@ -104,7 +104,7 @@ WindowsDevSetupScripts convention.
 `winget configure` against a real DSC config can install packages, change
 registry values, disable services, and so on — not the kind of thing we
 want to launch on a stray Enter key. So `🪟 Run Windows Setup` is a
-[`ConfirmableCommand`](https://learn.microsoft.com/windows/powertoys/command-palette/):
+[`ConfirmableCommand`](https://learn.microsoft.com/windows/powertoys/command-palette/overview):
 selecting it pops a confirmation dialog with the script path and a short
 note that the flows are idempotent. Confirm to launch the wt.exe tab;
 cancel to back out.


### PR DESCRIPTION
## Summary

Fixes five broken cross-references in `src/` documentation, found by a
static markdown link scan of the repo. The top-level `README.md` and
the per-flow READMEs (`Windows Dev Config/README.md`, `Wsl Comfort/readme.md`)
were already clean — every broken link is inside `src/`.

## What was broken

| File | Line | Old target | Failure |
| ---- | ---- | ---------- | ------- |
| `src/docs/development.md` | 4 | `../README.md` | Resolves to `src/README.md` (doesn't exist). |
| `src/future/cmdpal/README.md` | 5 | `../manifest.yml` | Resolves to `src/future/manifest.yml` (doesn't exist; manifest is at `src/manifest.yml`). |
| `src/future/cmdpal/README.md` | 15 | `../README.md#prerequisites-windows` | Resolves to `src/future/README.md` (doesn't exist). The `#prerequisites-windows` anchor also only exists in `src/docs/development.md`, not in the top-level README. |
| `src/future/cmdpal/README.md` | 19 | `../scripts/windows/_common/assert-winget-configure.ps1` | Stale path; the file lives at `src/Workloads/_common/assert-winget-configure.ps1` in this repo. |
| `src/future/cmdpal/README.md` | 107 | `https://learn.microsoft.com/windows/powertoys/command-palette/` | 404. The overview page is at `/command-palette/overview`. |

## What this PR does

Three of the four relative-link fixes are pure path corrections (one
more `..` segment to escape `src/`'s subdirectories properly).

Two also adjust the link **text** so it matches the destination:

- The `Prerequisites (Windows)` cross-reference originally said "top-level
  README's Prerequisites section" but the anchor `#prerequisites-windows`
  only exists in `src/docs/development.md`'s "Prerequisites (Windows)"
  header. Repointed to `src/docs/development.md#prerequisites-windows`
  and changed the link text to "the developer guide's `Prerequisites
  (Windows)`" so the description matches what readers land on.
- The `assert-winget-configure.ps1` reference originally displayed the
  path `scripts/windows/_common/assert-winget-configure.ps1` and pointed
  at the same. Updated both the displayed path and the target to
  `Workloads/_common/assert-winget-configure.ps1`, the current layout.

The single absolute-URL fix appends `/overview` to the MS Learn URL
(verified 200).

## Verification

Re-ran the same link scan on the patched tree: **0 broken** out of 182
links. Diff is +7 / -7 across two files.

```
src/docs/development.md     |  2 +-
src/future/cmdpal/README.md | 12 ++++++------
```
