### PR TITLE
Docs: explain src/ vs the signed top-level copies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ A [PowerToys Command Palette](https://learn.microsoft.com/en-us/windows/powertoy
 
 See [`src/future/cmdpal/README.md`](./src/future/cmdpal/README.md) for build and install instructions.
 
+## Troubleshooting
+
+- **"Unrecognized command: configure"** - run `winget configure --enable`. If `winget configure` is still unavailable, see [`Workloads/_common/assert-winget-configure.ps1`](./Workloads/_common/assert-winget-configure.ps1).
+- **A workload says it succeeded but `python` / `node` / similar commands are not on PATH in this window.** Open a new terminal, or use the matching `install.ps1` shim to refresh PATH in the current session.
+- **Windows Dev Config rebooted the machine and appears to have stopped.** It registers a `RunOnce` entry so `winget configure` resumes after you sign back in.
+- **WSL is missing when you tried to run the Comfort Shell bootstrap directly.** Use `& ".\Wsl Comfort\install.ps1"` on Windows so the flow can install WSL first.
+
 ## Repo layout: signed vs source
 
 This repo carries **two parallel copies** of every flow:
@@ -119,14 +126,7 @@ This repo carries **two parallel copies** of every flow:
 - Don't edit a top-level signed copy directly. The next sign cycle will overwrite it, and the cycle signs `src/`, not the top level.
 - Don't expect the two trees to be byte-identical. The signed copies carry an Authenticode signature block (`# SIG # Begin signature block` … `# SIG # End signature block`); the bodies above that marker should match what's in `src/`. They will diverge for the window between a `src/` change landing on `main` and the next sign cycle catching up.
 - Don't add a third copy of anything. Both copies exist for one reason only — to ship signed PS1s without losing the unsigned source — and any new flow or shared script lives only in `src/` until the sign pipeline mirrors it.
-
-## Troubleshooting
-
-- **"Unrecognized command: configure"** - run `winget configure --enable`. If `winget configure` is still unavailable, see [`Workloads/_common/assert-winget-configure.ps1`](./Workloads/_common/assert-winget-configure.ps1).
-- **A workload says it succeeded but `python` / `node` / similar commands are not on PATH in this window.** Open a new terminal, or use the matching `install.ps1` shim to refresh PATH in the current session.
-- **Windows Dev Config rebooted the machine and appears to have stopped.** It registers a `RunOnce` entry so `winget configure` resumes after you sign back in.
-- **WSL is missing when you tried to run the Comfort Shell bootstrap directly.** Use `& ".\Wsl Comfort\install.ps1"` on Windows so the flow can install WSL first.
-
+- 
 ## License
 
 [MIT](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -91,6 +91,35 @@ A [PowerToys Command Palette](https://learn.microsoft.com/en-us/windows/powertoy
 
 See [`src/future/cmdpal/README.md`](./src/future/cmdpal/README.md) for build and install instructions.
 
+## Repo layout: signed vs source
+
+This repo carries **two parallel copies** of every flow:
+
+| Path                          | What it is                                                        | Edit it? | Run it?  |
+| ----------------------------- | ----------------------------------------------------------------- | -------- | -------- |
+| `Windows Dev Config/`         | **Signed release copy** (Authenticode).                           | No       | **Yes**  |
+| `Workloads/`                  | **Signed release copy** of every single-language workload.        | No       | **Yes**  |
+| `Wsl Comfort/`                | **Signed release copy**.                                          | No       | **Yes**  |
+| `src/Windows Dev Config/`     | Source. CI runs from here.                                        | **Yes**  | Yes      |
+| `src/Workloads/`              | Source. CI runs from here.                                        | **Yes**  | Yes      |
+| `src/Wsl Comfort/`            | Source. CI runs from here.                                        | **Yes**  | Yes      |
+| `src/manifest.yml`            | Single source-of-truth for every flow (paths, build/run, ids).    | **Yes**  | n/a      |
+| `src/future/cmdpal/`          | Command Palette extension. C# project. Reads `src/manifest.yml`.  | **Yes**  | n/a      |
+| `src/docs/development.md`     | Contributor docs (CI, validation, how to add a language).         | **Yes**  | n/a      |
+| `src/tests/`                  | Hello-world programs + expected stdout used by the CI harness.    | **Yes**  | CI only  |
+
+**End users**: the commands in this README point at the **top-level signed copies** on purpose. If you're following the README on a Windows box you don't need to know `src/` exists — every `winget configure -f ".\Windows Dev Config\dev-config.winget"`-style invocation in this README is correct as written.
+
+**Contributors**: edit `src/`. The top-level paths are **regenerated** by [`.pipelines/OneBranch.SignAndPackage.yml`](./.pipelines/OneBranch.SignAndPackage.yml), which Authenticode-signs every `src/**/*.ps1` and ships them (plus the `.winget` configs and the manifest) as the release artifact. The signed copies were merged into `main` from the `signed` branch in [PR #6](https://github.com/microsoft/WindowsDeveloperConfig/pull/6). A change to a `src/` script becomes a new signed top-level copy on the next sign cycle, not at PR merge — so the two can briefly disagree on a script's body until that cycle runs.
+
+**CI**: GitHub Actions ([`.github/workflows/ci.yml`](./.github/workflows/ci.yml)) runs the **unsigned `src/` copies** (e.g. `./src/Workloads/_common/preflight.ps1`). This is intentional — CI exercises what contributors edit; signing is a release-time concern, not a build-time one.
+
+**Don't**:
+
+- Don't edit a top-level signed copy directly. The next sign cycle will overwrite it, and the cycle signs `src/`, not the top level.
+- Don't expect the two trees to be byte-identical. The signed copies carry an Authenticode signature block (`# SIG # Begin signature block` … `# SIG # End signature block`); the bodies above that marker should match what's in `src/`. They will diverge for the window between a `src/` change landing on `main` and the next sign cycle catching up.
+- Don't add a third copy of anything. Both copies exist for one reason only — to ship signed PS1s without losing the unsigned source — and any new flow or shared script lives only in `src/` until the sign pipeline mirrors it.
+
 ## Troubleshooting
 
 - **"Unrecognized command: configure"** - run `winget configure --enable`. If `winget configure` is still unavailable, see [`Workloads/_common/assert-winget-configure.ps1`](./Workloads/_common/assert-winget-configure.ps1).


### PR DESCRIPTION
## Summary

Adds a `Repo layout: signed vs source` section to the top-level
`README.md`. Pure documentation change; no code or file moves.

## Why

The repo carries **two parallel copies** of every flow:

- `Windows Dev Config/`, `Workloads/`, `Wsl Comfort/` at the top level — **Authenticode-signed** release copies.
- `src/Windows Dev Config/`, `src/Workloads/`, `src/Wsl Comfort/` — the **unsigned source** contributors edit and CI runs from.

The README's `winget configure -f ".\Windows Dev Config\dev-config.winget"`-style commands all point at the **top-level signed copies**, while `.github/workflows/ci.yml` and `src/docs/development.md` point at `src/`. Today nothing in the top-level README mentions the split at all, so a first-time reader genuinely can't tell:

- which directory is canonical,
- which one to edit if they want to contribute,
- why a `src/Windows Dev Config/` even exists next to `Windows Dev Config/`,
- or why the signed copies appeared in the repo (they were merged from the `signed` branch in #6).

## What the new section says

A small 4-column table covering every top-level and `src/` path with **what it is**, **edit it?**, and **run it?**, followed by four short prose blocks aimed at distinct readers:

- **End users** — the README's commands point at the top-level signed copies on purpose; you don't need to know `src/` exists.
- **Contributors** — edit `src/`; the top-level paths are regenerated by `.pipelines/OneBranch.SignAndPackage.yml`; the signed copies were merged from `signed` in #6; a `src/` edit only becomes a new signed top-level copy on the next sign cycle, not at PR merge.
- **CI** — runs the unsigned `src/` copies on purpose; signing is a release-time concern, not a build-time one.
- **Don't** — three concrete anti-patterns (don't edit a top-level signed copy, don't expect byte-identity outside the signature block, don't add a third copy).

## Placement

Inserted between the existing **Command Palette extension** and **Troubleshooting** sections. A reader who's already read the flow descriptions hits the layout section right when they start looking around the repo.

## Diff

```
README.md | 29 +++++++++++++++++++++++++++++
1 file changed, 29 insertions(+)
```

29 lines added, 0 removed, no other files touched.
