### PR TITLE
Docs: kebab-case the Repo layout table after rename PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,18 +104,18 @@ This repo carries **two parallel copies** of every flow:
 
 | Path                          | What it is                                                        | Edit it? | Run it?  |
 | ----------------------------- | ----------------------------------------------------------------- | -------- | -------- |
-| `Windows Dev Config/`         | **Signed release copy** (Authenticode).                           | No       | **Yes**  |
+| `windows-dev-config/`         | **Signed release copy** (Authenticode).                           | No       | **Yes**  |
 | `Workloads/`                  | **Signed release copy** of every single-language workload.        | No       | **Yes**  |
-| `Wsl Comfort/`                | **Signed release copy**.                                          | No       | **Yes**  |
-| `src/Windows Dev Config/`     | Source. CI runs from here.                                        | **Yes**  | Yes      |
+| `wsl-comfort/`                | **Signed release copy**.                                          | No       | **Yes**  |
+| `src/windows-dev-config/`     | Source. CI runs from here.                                        | **Yes**  | Yes      |
 | `src/Workloads/`              | Source. CI runs from here.                                        | **Yes**  | Yes      |
-| `src/Wsl Comfort/`            | Source. CI runs from here.                                        | **Yes**  | Yes      |
+| `src/wsl-comfort/`            | Source. CI runs from here.                                        | **Yes**  | Yes      |
 | `src/manifest.yml`            | Single source-of-truth for every flow (paths, build/run, ids).    | **Yes**  | n/a      |
 | `src/future/cmdpal/`          | Command Palette extension. C# project. Reads `src/manifest.yml`.  | **Yes**  | n/a      |
 | `src/docs/development.md`     | Contributor docs (CI, validation, how to add a language).         | **Yes**  | n/a      |
 | `src/tests/`                  | Hello-world programs + expected stdout used by the CI harness.    | **Yes**  | CI only  |
 
-**End users**: the commands in this README point at the **top-level signed copies** on purpose. If you're following the README on a Windows box you don't need to know `src/` exists — every `winget configure -f ".\Windows Dev Config\dev-config.winget"`-style invocation in this README is correct as written.
+**End users**: the commands in this README point at the **top-level signed copies** on purpose. If you're following the README on a Windows box you don't need to know `src/` exists — every `winget configure -f .\windows-dev-config\dev-config.winget`-style invocation in this README is correct as written.
 
 **Contributors**: edit `src/`. The top-level paths are **regenerated** by [`.pipelines/OneBranch.SignAndPackage.yml`](./.pipelines/OneBranch.SignAndPackage.yml), which Authenticode-signs every `src/**/*.ps1` and ships them (plus the `.winget` configs and the manifest) as the release artifact. The signed copies were merged into `main` from the `signed` branch in [PR #6](https://github.com/microsoft/WindowsDeveloperConfig/pull/6). A change to a `src/` script becomes a new signed top-level copy on the next sign cycle, not at PR merge — so the two can briefly disagree on a script's body until that cycle runs.
 
@@ -126,7 +126,7 @@ This repo carries **two parallel copies** of every flow:
 - Don't edit a top-level signed copy directly. The next sign cycle will overwrite it, and the cycle signs `src/`, not the top level.
 - Don't expect the two trees to be byte-identical. The signed copies carry an Authenticode signature block (`# SIG # Begin signature block` … `# SIG # End signature block`); the bodies above that marker should match what's in `src/`. They will diverge for the window between a `src/` change landing on `main` and the next sign cycle catching up.
 - Don't add a third copy of anything. Both copies exist for one reason only — to ship signed PS1s without losing the unsigned source — and any new flow or shared script lives only in `src/` until the sign pipeline mirrors it.
-- 
+
 ## License
 
 [MIT](./LICENSE).


### PR DESCRIPTION
When PRs #8 and #9 landed in that order, PR #8's 'Repo layout: signed vs source' section was merged with the spaced paths (Windows Dev Config/, Wsl Comfort/) baked in, and PR #9's rename did not retroactively update that table. After both PRs the README points readers at four paths that no longer exist on disk.

Three small fixes, all inside the Repo layout section:

- Update the 4-column path table to kebab-case: windows-dev-config/, wsl-comfort/, src/windows-dev-config/, src/wsl-comfort/.
- Update the inline 'every winget configure -f ...-style invocation in this README is correct as written' example to drop the now-unnecessary surrounding quotes and use windows-dev-config.
- Remove the stray '- ' empty bullet that landed at the end of the 'Don't' list (likely a stray trailing dash in the PR #8 source).

No new content. No structural changes elsewhere.