### PR TITLE
Docs: name src/manifest.yml as the flow source of truth in Contributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,5 @@ This repo carries **two parallel copies** of every flow:
 ## Contributing
 
 For repository layout, CI, and instructions for adding or validating flows, see [`src/docs/development.md`](./src/docs/development.md).
+
+The single source of truth for every flow (paths, build and run commands, ids, language metadata) is [`src/manifest.yml`](./src/manifest.yml). The Command Palette extension, the CI harness, and the per-flow shims all read from it - keep it in sync when adding or renaming a flow.


### PR DESCRIPTION
src/manifest.yml is the single file driving everything in this repo - the Command Palette extension, the CI harness, the per-flow shims, and src/docs/development.md all consume it. A new contributor reading the top-level README has no idea it exists, and may add a flow without updating it (or update it incorrectly).

Add one sentence to the Contributing section pointing readers at src/manifest.yml and explaining that it is the source of truth for paths, build/run commands, ids, and language metadata.

No other changes; src/docs/development.md remains the deeper contributor doc.