### PR TITLE
Docs: remove stale 'Filename mismatch with install.ps1' caveat

### DIFF
--- a/src/windows-dev-config/README.md
+++ b/src/windows-dev-config/README.md
@@ -197,7 +197,6 @@ HKLM policies, applied via `Microsoft.Windows/Registry`:
 
 | Area | Caveat |
 |------|--------|
-| **Filename mismatch with `install.ps1`** | `install.ps1` in this directory invokes `_common\apply-configuration.ps1` with `-ConfigFile configuration.winget`, but the file is named `dev-config.winget`. Running `install.ps1` will fail on the missing-file check. Apply the config directly with `winget configure -f dev-config.winget …` (see [Usage](#usage)) until either the file is renamed or the shim is updated. |
 | **`acceptAgreements` not on packages** | None of the `Microsoft.WinGet/Package` resources set `acceptAgreements: true`. The header comment compensates by passing `--accept-configuration-agreements` to the CLI invocation, but `--accept-package-agreements` is **not** in the documented command — first-time installs may prompt. Pass it explicitly if you want fully silent. |
 | **WSL reboot** | `RebootForVmp` will hard-reboot the machine via `Restart-Computer -Force`. Save your work before running. The RunOnce key resumes the config on next login. |
 | **Ubuntu first-launch** | After `InstallUbuntu`, you still need to open Ubuntu from the Start menu once to create a UNIX user. Nothing inside the distro is configured by this flow. |

--- a/windows-dev-config/README.md
+++ b/windows-dev-config/README.md
@@ -197,7 +197,6 @@ HKLM policies, applied via `Microsoft.Windows/Registry`:
 
 | Area | Caveat |
 |------|--------|
-| **Filename mismatch with `install.ps1`** | `install.ps1` in this directory invokes `_common\apply-configuration.ps1` with `-ConfigFile configuration.winget`, but the file is named `dev-config.winget`. Running `install.ps1` will fail on the missing-file check. Apply the config directly with `winget configure -f dev-config.winget …` (see [Usage](#usage)) until either the file is renamed or the shim is updated. |
 | **`acceptAgreements` not on packages** | None of the `Microsoft.WinGet/Package` resources set `acceptAgreements: true`. The header comment compensates by passing `--accept-configuration-agreements` to the CLI invocation, but `--accept-package-agreements` is **not** in the documented command — first-time installs may prompt. Pass it explicitly if you want fully silent. |
 | **WSL reboot** | `RebootForVmp` will hard-reboot the machine via `Restart-Computer -Force`. Save your work before running. The RunOnce key resumes the config on next login. |
 | **Ubuntu first-launch** | After `InstallUbuntu`, you still need to open Ubuntu from the Start menu once to create a UNIX user. Nothing inside the distro is configured by this flow. |


### PR DESCRIPTION
windows-dev-config/README.md (and the src/ mirror) lists a 'Known caveats' row claiming install.ps1 passes -ConfigFile configuration.winget but the actual file is dev-config.winget, so running install.ps1 fails. The caveat is wrong against the code that is committed today:

  src/windows-dev-config/install.ps1 line 28:
      -ConfigFile (Join-Path \ 'dev-config.winget')

The signed top-level windows-dev-config/install.ps1 mirrors that. So install.ps1 already calls the correct file; the caveat reads as a recommendation to use the .winget directly when there is in fact no problem with the shim.

Remove the row from both copies of the README (src/windows-dev-config/README.md and the signed top-level windows-dev-config/README.md). The remaining three caveats (acceptAgreements, WSL reboot, Ubuntu first-launch) are unchanged.