### PR TITLE
Update dev-config.winget with Win Skills

### DIFF
--- a/src/windows-dev-config/dev-config.winget
+++ b/src/windows-dev-config/dev-config.winget
@@ -441,29 +441,6 @@ resources:
     valueData:
       DWord: 0
 
-- type: Microsoft.DSC.Transitional/RunCommandOnSet
-  name: DoNotDisturbCloudStoreBlob
-  dependsOn:
-  - DoNotDisturb
-  properties:
-    executable: powershell.exe
-    arguments:
-    - -NoProfile
-    - -ExecutionPolicy
-    - Bypass
-    - -Command
-    - |
-      $p = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\CloudStore\Store\Cache\DefaultAccount\$$windows.data.notifications.quiethourssettings\Current'
-      if (Test-Path $p) {
-        $d = (Get-ItemProperty -Path $p -Name Data).Data
-        if ($d.Length -gt 0x32 -and $d[0x32] -ne 1) {
-          $d[0x32] = 1
-          Set-ItemProperty -Path $p -Name Data -Value $d
-        }
-      }
-  metadata:
-    description: Flip the DND byte at offset 0x32 in the CloudStore quiethourssettings blob so the Settings/bell-icon toggle reflects 'On'
-
 # =============================================================================
 # Taskbar
 # =============================================================================

--- a/src/windows-dev-config/dev-config.winget
+++ b/src/windows-dev-config/dev-config.winget
@@ -440,6 +440,28 @@ resources:
     valueName: NOC_GLOBAL_SETTING_TOASTS_ENABLED
     valueData:
       DWord: 0
+- type: Microsoft.DSC.Transitional/RunCommandOnSet
+  name: DoNotDisturbCloudStoreBlob
+  dependsOn:
+  - DoNotDisturbToasts
+  properties:
+    executable: powershell.exe
+    arguments:
+    - -NoProfile
+    - -ExecutionPolicy
+    - Bypass
+    - -Command
+    - |
+      $p = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\CloudStore\Store\Cache\DefaultAccount\$$windows.data.notifications.quiethourssettings\Current'
+      if (Test-Path $p) {
+        $d = (Get-ItemProperty -Path $p -Name Data).Data
+        if ($d.Length -gt 0x32 -and $d[0x32] -ne 1) {
+          $d[0x32] = 1
+          Set-ItemProperty -Path $p -Name Data -Value $d
+        }
+      }
+  metadata:
+    description: Flip the DND byte at offset 0x32 in the CloudStore quiethourssettings blob so the Settings/bell-icon toggle reflects 'On'
 
 # =============================================================================
 # Taskbar
@@ -928,3 +950,28 @@ resources:
       treatAsArray: true
   metadata:
     description: Create Github Copilot Profile
+
+# =============================================================================
+# Script-Based Items (RunCommandOnSet)
+# PowerShell :: Microsoft.DSC.Transitional/PowerShellScript should be what we use 
+#
+# Copilot in PS profile
+# =============================================================================
+- type: Microsoft.DSC.Transitional/RunCommandOnSet
+  name: WinSkills
+  dependsOn:
+    - GitHubCopilot
+    - DotnetSdk
+  properties:
+    executable: pwsh.exe
+    arguments:
+      "0": -NoProfile
+      "1": -NoLogo
+      "2": -Command
+      "3": |
+         dotnet new install Microsoft.WindowsAppSDK.WinUI.CSharp.Templates
+         copilot plugin marketplace add microsoft/win-dev-skills
+         copilot plugin install winui@win-dev-skills
+      treatAsArray: true
+  metadata:
+    description: Install Win Skills

--- a/src/windows-dev-config/dev-config.winget
+++ b/src/windows-dev-config/dev-config.winget
@@ -440,10 +440,11 @@ resources:
     valueName: NOC_GLOBAL_SETTING_TOASTS_ENABLED
     valueData:
       DWord: 0
+
 - type: Microsoft.DSC.Transitional/RunCommandOnSet
   name: DoNotDisturbCloudStoreBlob
   dependsOn:
-  - DoNotDisturbToasts
+  - DoNotDisturb
   properties:
     executable: powershell.exe
     arguments:


### PR DESCRIPTION
This pull request adds a new script-based configuration step to the `src/windows-dev-config/dev-config.winget` file. The main change is the introduction of a `RunCommandOnSet` resource for setting up Win Skills using PowerShell, which depends on `GitHubCopilot` and `DotnetSdk`.

**Script-based configuration enhancements:**

* Added a new `Microsoft.DSC.Transitional/RunCommandOnSet` resource named `WinSkills` to automate the installation of Win Skills and related plugins using PowerShell, with dependencies on `GitHubCopilot` and `DotnetSdk`.