### PR TITLE
More README tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ---
 
-Setting up a Windows dev box by hand is slow, fiddly, and never quite the same twice. This repo replaces all that with a handful of declarative, CI-tested configs that take a fresh machine to a working dev environment in one command — repeatably, on any box.
+Go from a fresh Windows install to a fully configured dev box in one command. These declarative, CI-tested configs set up your tools, settings, and shells the same way every time — so any machine can be your machine in minutes.
 
 ## 🎯 Pick your setup
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Want the PATH refresh in your current shell? Use the matching shim instead of ca
 
 ## 🎨 Command Palette extension coming soon
 
-A [PowerToys Command Palette](https://learn.microsoft.com/en-us/windows/powertoys/command-palette/overview) extension lives under [`src/future/cmdpal/`](./src/future/cmdpal/). It reads the same flow list as the rest of the repo and surfaces every flow as a launchable entry, so you don't have to remember which `configuration.winget` to point `winget` at.
+A [PowerToys Command Palette](https://learn.microsoft.com/windows/powertoys/command-palette/overview) extension lives under [`src/future/cmdpal/`](./src/future/cmdpal/). It reads the same flow list as the rest of the repo and surfaces every flow as a launchable entry, so you don't have to remember which `configuration.winget` to point `winget` at.
 
 See [`src/future/cmdpal/README.md`](./src/future/cmdpal/README.md) for build and install instructions.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 
 ---
 
+Setting up a Windows dev box by hand is slow, fiddly, and never quite the same twice. This repo replaces all that with a handful of declarative, CI-tested configs that take a fresh machine to a working dev environment in one command — repeatably, on any box.
+
 ## 🎯 Pick your setup
 
 Three different things live in this repo. Pick the one that matches what you actually want:

--- a/src/docs/development.md
+++ b/src/docs/development.md
@@ -54,7 +54,7 @@ list (paths, build/run commands, onboarding URLs).
 
 ## Command Palette extension
 
-A [PowerToys Command Palette](https://learn.microsoft.com/en-us/windows/powertoys/command-palette/overview)
+A [PowerToys Command Palette](https://learn.microsoft.com/windows/powertoys/command-palette/overview)
 extension lives under [`future/cmdpal/`](../future/cmdpal/). It reads the same
 `manifest.yml` as CI and lets you browse + launch any flow without remembering
 which `configuration.winget` to point `winget` at.

--- a/src/future/cmdpal/README.md
+++ b/src/future/cmdpal/README.md
@@ -1,6 +1,6 @@
 # QuickWingetSetup — Command Palette extension
 
-A [PowerToys Command Palette](https://learn.microsoft.com/en-us/windows/powertoys/command-palette/overview)
+A [PowerToys Command Palette](https://learn.microsoft.com/windows/powertoys/command-palette/overview)
 extension that surfaces the developer flows defined in this repo's
 [`manifest.yml`](../../manifest.yml). Pick a flow, hit Enter, and the extension
 launches `winget configure` (Windows) or `wsl bash` (Linux) in a new Windows

--- a/src/manifest.yml
+++ b/src/manifest.yml
@@ -106,7 +106,7 @@ flows:
     category: desktop
     tags: [dotnet, csharp, winforms, windows, desktop]
     icon: 🪟
-    onboardingUrl: https://learn.microsoft.com/en-us/dotnet/desktop/winforms/overview/
+    onboardingUrl: https://learn.microsoft.com/dotnet/desktop/winforms/overview/
     # Excluded from the automated matrix because the install pulls the .NET
     # desktop workload (effectively the Visual Studio build tools), which is
     # multi-GB and dominates the CI minute budget. Verified working locally
@@ -127,7 +127,7 @@ flows:
     category: desktop
     tags: [dotnet, csharp, winui, windows, desktop, windowsappsdk]
     icon: 🪟
-    onboardingUrl: https://learn.microsoft.com/en-us/windows/apps/winui/winui3/
+    onboardingUrl: https://learn.microsoft.com/windows/apps/winui/winui3/
     # WinUI hello world needs an interactive desktop session to actually run;
     # CI only validates that the configuration applies cleanly. The build/run
     # fields stay populated so a human can execute the flow locally.
@@ -147,7 +147,7 @@ flows:
     category: languages
     tags: [dotnet, csharp, fsharp, net]
     icon: 🟣
-    onboardingUrl: https://learn.microsoft.com/en-us/dotnet/core/install/windows
+    onboardingUrl: https://learn.microsoft.com/dotnet/core/install/windows
     os: [windows]
     windows:
       install: Workloads/dotnet/install.ps1
@@ -179,7 +179,7 @@ flows:
     category: languages
     tags: [java, jdk, openjdk, jvm]
     icon: ☕
-    onboardingUrl: https://learn.microsoft.com/en-us/java/openjdk/install
+    onboardingUrl: https://learn.microsoft.com/java/openjdk/install
     os: [windows]
     windows:
       install: Workloads/java/install.ps1

--- a/src/windows-dev-config/dev-config.winget
+++ b/src/windows-dev-config/dev-config.winget
@@ -543,7 +543,7 @@ resources:
 # =============================================================================
 # Registry — HKLM keys (elevated, native v3 Microsoft.Windows/Registry)
 #
-# Microsoft Edge policies — https://learn.microsoft.com/en-us/deployedge/microsoft-edge-policies#newtabpage
+# Microsoft Edge policies — https://learn.microsoft.com/deployedge/microsoft-edge-policies#newtabpage
 # =============================================================================
 
 - type: Microsoft.Windows/Registry

--- a/windows-dev-config/dev-config.winget
+++ b/windows-dev-config/dev-config.winget
@@ -543,7 +543,7 @@ resources:
 # =============================================================================
 # Registry — HKLM keys (elevated, native v3 Microsoft.Windows/Registry)
 #
-# Microsoft Edge policies — https://learn.microsoft.com/en-us/deployedge/microsoft-edge-policies#newtabpage
+# Microsoft Edge policies — https://learn.microsoft.com/deployedge/microsoft-edge-policies#newtabpage
 # =============================================================================
 
 - type: Microsoft.Windows/Registry


### PR DESCRIPTION
Adds a one-line intro between the top-level nav and the 'Pick your setup' table, framing what the repo is and what it solves before jumping into the picker. removes en-us from links