### PR TITLE
Update OpenJDK from 21 to 25 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Just want one toolchain? Pick a row. Each workload ships a `configuration.winget
 | PHP        | PHP 8.5                                                                 | `winget configure -f .\Workloads\php\configuration.winget --accept-configuration-agreements --disable-interactivity`        |
 | .NET       | .NET SDK 10                                                             | `winget configure -f .\Workloads\dotnet\configuration.winget --accept-configuration-agreements --disable-interactivity`     |
 | Go         | Go (rolling)                                                            | `winget configure -f .\Workloads\go\configuration.winget --accept-configuration-agreements --disable-interactivity`         |
-| Java       | Microsoft Build of OpenJDK 21 LTS                                       | `winget configure -f .\Workloads\java\configuration.winget --accept-configuration-agreements --disable-interactivity`       |
+| Java       | Microsoft Build of OpenJDK 25 LTS                                       | `winget configure -f .\Workloads\java\configuration.winget --accept-configuration-agreements --disable-interactivity`       |
 | Rust       | Rust stable via rustup                                                  | `winget configure -f .\Workloads\rust\configuration.winget --accept-configuration-agreements --disable-interactivity`       |
 | Python     | Python 3.13 + uv                                                       | `winget configure -f .\Workloads\python\configuration.winget --accept-configuration-agreements --disable-interactivity`     |
 | WinForms   | .NET SDK 10 + Windows Forms desktop workload                            | `winget configure -f .\Workloads\winforms\configuration.winget --accept-configuration-agreements --disable-interactivity`   |
@@ -128,7 +128,7 @@ Want the PATH refresh in your current shell? Use the matching shim instead of ca
 
 <br/>
 
-## 🎨 Command Palette extension
+## 🎨 Command Palette extension (coming soon)
 
 A [PowerToys Command Palette](https://learn.microsoft.com/windows/powertoys/command-palette/overview) extension lives under [`src/future/cmdpal/`](./src/future/cmdpal/). It reads the same flow list as the rest of the repo and surfaces every flow as a launchable entry, so you don't have to remember which `configuration.winget` to point `winget` at.
 

--- a/Workloads/java/configuration.winget
+++ b/Workloads/java/configuration.winget
@@ -12,7 +12,7 @@ resources:
   - name: OpenJdk
     type: Microsoft.WinGet/Package
     properties:
-      id: Microsoft.OpenJDK.21
+      id: Microsoft.OpenJDK.25
       source: winget
       acceptAgreements: true
     metadata:

--- a/Workloads/java/install.ps1
+++ b/Workloads/java/install.ps1
@@ -5,7 +5,7 @@
 .DESCRIPTION
   This script is a thin CI/dev shim. The core artifact for the Java flow is
   `configuration.winget` in this directory - a winget DSC configuration that
-  declaratively installs the Microsoft Build of OpenJDK 21 (LTS) via winget.
+  declaratively installs the Microsoft Build of OpenJDK 25 (LTS) via winget.
 
   The shim exists only to:
     * apply the DSC config with retry (hosted-runner networks are flaky),

--- a/src/Workloads/java/configuration.winget
+++ b/src/Workloads/java/configuration.winget
@@ -12,7 +12,7 @@ resources:
   - name: OpenJdk
     type: Microsoft.WinGet/Package
     properties:
-      id: Microsoft.OpenJDK.21
+      id: Microsoft.OpenJDK.25
       source: winget
       acceptAgreements: true
     metadata:

--- a/src/Workloads/java/install.ps1
+++ b/src/Workloads/java/install.ps1
@@ -5,7 +5,7 @@
 .DESCRIPTION
   This script is a thin CI/dev shim. The core artifact for the Java flow is
   `configuration.winget` in this directory - a winget DSC configuration that
-  declaratively installs the Microsoft Build of OpenJDK 21 (LTS) via winget.
+  declaratively installs the Microsoft Build of OpenJDK 25 (LTS) via winget.
 
   The shim exists only to:
     * apply the DSC config with retry (hosted-runner networks are flaky),

--- a/src/docs/development.md
+++ b/src/docs/development.md
@@ -41,7 +41,7 @@ extension.
 | PHP               | ✅ automated   | `PHP.PHP.8.5`                                                                           |
 | .NET              | ✅ automated   | `Microsoft.DotNet.SDK.10`                                                               |
 | Go                | ✅ automated   | `GoLang.Go` (rolling — winget publishes Go unversioned)                                 |
-| Java              | ✅ automated   | `Microsoft.OpenJDK.21`                                                                  |
+| Java              | ✅ automated   | `Microsoft.OpenJDK.25`                                                                  |
 | Rust              | ✅ automated   | `Rustlang.Rustup` (then `rustup default stable`)                                        |
 | Python            | ✅ automated   | `Python.Python.3.13`, `astral-sh.uv`                                                    |
 | WinForms          | 🙋 manual     | `Microsoft.DotNet.SDK.10` + the .NET desktop workload (multi-GB; manual to spare CI minutes) |

--- a/src/manifest.yml
+++ b/src/manifest.yml
@@ -175,7 +175,7 @@ flows:
 
   - id: java
     name: Java
-    description: Microsoft Build of OpenJDK 21 LTS (foundation for the web-api-java scenario)
+    description: Microsoft Build of OpenJDK 25 LTS (foundation for the web-api-java scenario)
     category: languages
     tags: [java, jdk, openjdk, jvm]
     icon: ☕


### PR DESCRIPTION
Updates the Java workload from Microsoft Build of OpenJDK 21 LTS to OpenJDK 25 LTS across all configuration files, documentation, and manifest.

## Changes
- `Workloads/java/configuration.winget` — `Microsoft.OpenJDK.21` → `Microsoft.OpenJDK.25`
- `Workloads/java/install.ps1` — comment updated
- `README.md` — workload table updated
- `src/manifest.yml` — flow description updated
- `src/docs/development.md` — CI table updated
- `src/Workloads/java/configuration.winget` — `Microsoft.OpenJDK.21` → `Microsoft.OpenJDK.25`
- `src/Workloads/java/install.ps1` — comment updated

Closes #23