### PR TITLE
Fix stale JetBrainsMono Nerd Font reference in root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Interactive by default. Use `-NonInteractive` for unattended runs; the bootstrap
 - Optional clipboard and `open` shims (`pbcopy`, `pbpaste`, `open`).
 - Optional **Homebrew**.
 - Optional Git defaults.
-- A themed **Windows Terminal** profile using JetBrainsMono Nerd Font.
+- A themed **Windows Terminal** profile using Cascadia Code Nerd Font.
 
 </details>
 


### PR DESCRIPTION
## Summary

The WSL Comfort installer was updated (PR #28) to use Cascadia Code Nerd Fonts instead of JetBrainsMono, and PR #30 caught most of the doc references — but one bullet in the root `README.md` WSL Comfort details block was missed.

## Change

- `README.md` L97: "JetBrainsMono Nerd Font" → "Cascadia Code Nerd Font"

No functional changes.