### PR TITLE
Update README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ If that fails or `winget configure` is still not recognized, see [Troubleshootin
 
 A single [winget configuration](https://learn.microsoft.com/en-us/windows/package-manager/configuration/) file that installs dev tools, applies opinionated Windows settings, and bootstraps WSL + Ubuntu through the required reboot. Non-interactive. Idempotent. Safe to re-run on an existing machine.
 
+First, get the files onto the box. The config is invoked from a local path, but the bootstrap itself is what installs Git — so on a clean Windows install you'll typically download the repo as a ZIP. If Git is already there, clone it:
+
+```powershell
+# Git already installed:
+git clone https://github.com/microsoft/WindowsDeveloperConfig.git
+cd WindowsDeveloperConfig
+
+# Otherwise, download and extract the ZIP:
+Invoke-WebRequest -Uri https://github.com/microsoft/WindowsDeveloperConfig/archive/refs/heads/main.zip -OutFile WindowsDeveloperConfig.zip
+Expand-Archive .\WindowsDeveloperConfig.zip -DestinationPath .
+cd .\WindowsDeveloperConfig-main
+```
+
+Then apply the configuration:
+
 ```powershell
 winget configure -f .\windows-dev-config\dev-config.winget --accept-configuration-agreements --disable-interactivity
 ```

--- a/src/windows-dev-config/README.md
+++ b/src/windows-dev-config/README.md
@@ -44,8 +44,22 @@ The flow is a single DSC document (`dev-config.winget`) that handles everything 
 - Windows 11 (latest).
 - `winget` with the DSC v3 processor available (the file uses `Microsoft.WinGet/Package`, `Microsoft.Windows/Registry`, and `Microsoft.DSC.Transitional/*`).
 - Administrator rights — the `ElevationCheck` resource will auto-relaunch winget elevated via `Start-Process -Verb RunAs` if you started in an unelevated session, but you'll need to consent at the UAC prompt.
+- The repo on disk. `winget configure` reads a local file path, and the bootstrap is what installs Git, so on a fresh machine you'll either `git clone` (if Git is already installed) or download the repo as a ZIP from GitHub and extract it before running.
 
 ## Usage
+
+**Get the files first** (skip if you already have the repo locally):
+
+```powershell
+# Git already installed:
+git clone https://github.com/microsoft/WindowsDeveloperConfig.git
+cd WindowsDeveloperConfig\windows-dev-config
+
+# Otherwise, download and extract the ZIP:
+Invoke-WebRequest -Uri https://github.com/microsoft/WindowsDeveloperConfig/archive/refs/heads/main.zip -OutFile WindowsDeveloperConfig.zip
+Expand-Archive .\WindowsDeveloperConfig.zip -DestinationPath .
+cd .\WindowsDeveloperConfig-main\windows-dev-config
+```
 
 **Full setup (recommended):**
 


### PR DESCRIPTION
This PR updates the documentation to clarify the setup steps before running the configuration.

Documentation updates:

Added instructions in README.md for cloning the repository with Git or downloading it as a ZIP before running winget configure.
Updated src/windows-dev-config/README.md with similar guidance for both Git and ZIP download scenarios.