### PR TITLE
Update README with vcredist requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ Most of them use [`winget configure`](https://learn.microsoft.com/en-us/windows/
 winget configure --enable
 ```
 
+> [!IMPORTANT]
+> If `winget` is being invoked from a **non-elevated** environment, the Microsoft Visual C++ Redistributable ([aka.ms/vcredist](https://aka.ms/vcredist)) must also be installed — without it `winget configure` fails with an internal error. Install it once with the command for your machine's architecture:
+>
+> ```powershell
+> # x64:
+> winget install Microsoft.VCRedist.2015+.x64
+>
+> # ARM64:
+> winget install Microsoft.VCRedist.2015+.arm64
+> ```
+
 If that fails or `winget configure` is still not recognized, see [Troubleshooting](#-troubleshooting).
 
 <br/>
@@ -137,6 +148,23 @@ See [`src/future/cmdpal/README.md`](./src/future/cmdpal/README.md) for build and
 <summary><strong>"Unrecognized command: configure"</strong></summary>
 
 Run `winget configure --enable`. If `winget configure` is still not recognized after that, [`Workloads/_common/assert-winget-configure.ps1`](./Workloads/_common/assert-winget-configure.ps1) tells you whether App Installer is too old, policy has disabled configuration, or something else needs fixing.
+
+</details>
+
+<details>
+<summary><strong><code>winget configure</code> fails with "internal error" / error code <code>-2146233079</code></strong></summary>
+
+This usually means the Microsoft Visual C++ Redistributable is missing — `winget configure` depends on it when invoked from a non-elevated environment. Install it once with the command for your architecture, then re-run:
+
+```powershell
+# x64:
+winget install Microsoft.VCRedist.2015+.x64
+
+# ARM64:
+winget install Microsoft.VCRedist.2015+.arm64
+```
+
+See [aka.ms/vcredist](https://aka.ms/vcredist) for the standalone installer. The repo's [`Workloads/_common/enable-winget-configure.ps1`](./Workloads/_common/enable-winget-configure.ps1) script also installs it automatically as part of enabling `winget configure`.
 
 </details>
 

--- a/src/windows-dev-config/README.md
+++ b/src/windows-dev-config/README.md
@@ -44,8 +44,20 @@ The flow is a single DSC document (`dev-config.winget`) that handles everything 
 - Windows 11 (latest).
 - `winget` with the DSC v3 processor available (the file uses `Microsoft.WinGet/Package`, `Microsoft.Windows/Registry`, and `Microsoft.DSC.Transitional/*`).
 - Administrator rights — the `ElevationCheck` resource will auto-relaunch winget elevated via `Start-Process -Verb RunAs` if you started in an unelevated session, but you'll need to consent at the UAC prompt.
+- The Microsoft Visual C++ Redistributable when invoking `winget` from a non-elevated environment. Without it, `winget configure` fails with an internal error. See [aka.ms/vcredist](https://aka.ms/vcredist) or install via winget (see the Usage callout below).
 
 ## Usage
+
+> [!IMPORTANT]
+> If `winget` is being invoked from a **non-elevated** environment, the Microsoft Visual C++ Redistributable ([aka.ms/vcredist](https://aka.ms/vcredist)) must also be installed — without it `winget configure` fails with an internal error. Install it once with the command for your machine's architecture:
+>
+> ```powershell
+> # x64:
+> winget install Microsoft.VCRedist.2015+.x64
+>
+> # ARM64:
+> winget install Microsoft.VCRedist.2015+.arm64
+> ```
 
 **Full setup (recommended):**
 


### PR DESCRIPTION
This PR improves winget configure documentation by clarifying that the Microsoft Visual C++ Redistributable is required when running winget from a non-elevated environment. It also adds troubleshooting guidance for resolving common internal errors caused by missing dependencies.

Updates
- Added notes in README.md and src/windows-dev-config/README.md explaining the Visual C++ Redistributable requirement and how to install it for different architectures.
- Expanded the troubleshooting section with steps to resolve error -2146233079 and referenced the script that automates the fix.