### PR TITLE
Document nested virtualization requirement for WSL in VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,15 +177,18 @@ Run `.\wsl-comfort\install.ps1` on the Windows side instead. It installs WSL fir
 </details>
 
 <details>
-<summary><strong>WSL install fails with <code>wsl --install ... failed with exit code -1</code> (typically inside a VM)</strong></summary>
+<summary><strong>WSL install fails with <code>wsl --install ... failed with exit code -1</code></strong></summary>
 
-If you're running Windows inside a virtual machine, the host needs **nested virtualization** enabled before WSL can install. For a Hyper-V host, run this from an elevated PowerShell session **on the host** (with the guest VM powered off):
+WSL needs hardware virtualization available to the OS. Two common root causes:
 
-```powershell
-Set-VMProcessor -VMName <VM_NAME> -ExposeVirtualizationExtensions $true
-```
+- **On bare metal:** virtualization (VT-x / AMD-V) is disabled in BIOS/UEFI. Reboot into firmware settings, enable it, save, and reboot back into Windows. The exact label varies by vendor — check your motherboard or laptop manufacturer's documentation if you can't find it.
+- **Inside a VM:** the host hasn't exposed nested virtualization to the guest. For a Hyper-V host, run this from an elevated PowerShell session **on the host** (with the guest VM powered off):
 
-Other hypervisors (VMware, VirtualBox, Parallels) have their own equivalent settings.
+  ```powershell
+  Set-VMProcessor -VMName <VM_NAME> -ExposeVirtualizationExtensions $true
+  ```
+
+  Other hypervisors have their own equivalent settings — check your hypervisor's documentation.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,19 @@ Run `.\wsl-comfort\install.ps1` on the Windows side instead. It installs WSL fir
 
 </details>
 
+<details>
+<summary><strong>WSL install fails with <code>wsl --install ... failed with exit code -1</code> (typically inside a VM)</strong></summary>
+
+If you're running Windows inside a virtual machine, the host needs **nested virtualization** enabled before WSL can install. For a Hyper-V host, run this from an elevated PowerShell session **on the host** (with the guest VM powered off):
+
+```powershell
+Set-VMProcessor -VMName <VM_NAME> -ExposeVirtualizationExtensions $true
+```
+
+Other hypervisors (VMware, VirtualBox, Parallels) have their own equivalent settings.
+
+</details>
+
 <br/>
 
 ## 🐛 Reporting issues

--- a/src/windows-dev-config/README.md
+++ b/src/windows-dev-config/README.md
@@ -45,18 +45,21 @@ The flow is a single DSC document (`dev-config.winget`) that handles everything 
 - `winget` with the DSC v3 processor available (the file uses `Microsoft.WinGet/Package`, `Microsoft.Windows/Registry`, and `Microsoft.DSC.Transitional/*`).
 - Administrator rights — the `ElevationCheck` resource will auto-relaunch winget elevated via `Start-Process -Verb RunAs` if you started in an unelevated session, but you'll need to consent at the UAC prompt.
 - The repo on disk. `winget configure` reads a local file path, and the bootstrap is what installs Git, so on a fresh machine you'll either `git clone` (if Git is already installed) or download the repo as a ZIP from GitHub and extract it before running.
-- If running inside a virtual machine, **nested virtualization must be enabled on the host** before WSL can install. See the Usage callout below.
+- **Hardware virtualization must be available to the OS** before WSL can install. On bare metal, this means virtualization (VT-x / AMD-V) is enabled in BIOS/UEFI. Inside a VM, it means the host has exposed nested virtualization to the guest. See the Usage callout below.
 
 ## Usage
 
 > [!IMPORTANT]
-> **Running inside a VM?** Nested virtualization must be enabled for WSL to install. For a Hyper-V host, run this from an elevated PowerShell session **on the host** (with the guest VM powered off):
+> **WSL needs hardware virtualization.** If virtualization isn't available to the OS, the `InstallUbuntu` step fails with `wsl --install ... failed with exit code -1`.
 >
-> ```powershell
-> Set-VMProcessor -VMName <VM_NAME> -ExposeVirtualizationExtensions $true
-> ```
+> - **On bare metal:** enable virtualization (VT-x / AMD-V) in your BIOS/UEFI. The exact label varies by vendor — check your motherboard or laptop manufacturer's documentation if you can't find it. Reboot into firmware settings, toggle it on, save, and reboot back into Windows.
+> - **Inside a VM:** the host must expose nested virtualization to the guest. For a Hyper-V host, run this from an elevated PowerShell session **on the host** (with the guest VM powered off):
 >
-> Other hypervisors (VMware, VirtualBox, Parallels) have their own equivalent settings. Without this, the `InstallUbuntu` step fails with `wsl --install ... failed with exit code -1`.
+>   ```powershell
+>   Set-VMProcessor -VMName <VM_NAME> -ExposeVirtualizationExtensions $true
+>   ```
+>
+>   Other hypervisors have their own equivalent settings — check your hypervisor's documentation.
 
 **Get the files first** (skip if you already have the repo locally):
 

--- a/src/windows-dev-config/README.md
+++ b/src/windows-dev-config/README.md
@@ -45,8 +45,18 @@ The flow is a single DSC document (`dev-config.winget`) that handles everything 
 - `winget` with the DSC v3 processor available (the file uses `Microsoft.WinGet/Package`, `Microsoft.Windows/Registry`, and `Microsoft.DSC.Transitional/*`).
 - Administrator rights — the `ElevationCheck` resource will auto-relaunch winget elevated via `Start-Process -Verb RunAs` if you started in an unelevated session, but you'll need to consent at the UAC prompt.
 - The repo on disk. `winget configure` reads a local file path, and the bootstrap is what installs Git, so on a fresh machine you'll either `git clone` (if Git is already installed) or download the repo as a ZIP from GitHub and extract it before running.
+- If running inside a virtual machine, **nested virtualization must be enabled on the host** before WSL can install. See the Usage callout below.
 
 ## Usage
+
+> [!IMPORTANT]
+> **Running inside a VM?** Nested virtualization must be enabled for WSL to install. For a Hyper-V host, run this from an elevated PowerShell session **on the host** (with the guest VM powered off):
+>
+> ```powershell
+> Set-VMProcessor -VMName <VM_NAME> -ExposeVirtualizationExtensions $true
+> ```
+>
+> Other hypervisors (VMware, VirtualBox, Parallels) have their own equivalent settings. Without this, the `InstallUbuntu` step fails with `wsl --install ... failed with exit code -1`.
 
 **Get the files first** (skip if you already have the repo locally):
 


### PR DESCRIPTION
Adds a callout and Prerequisites bullet in src/windows-dev-config/README.md, plus a Troubleshooting entry in the root README.md, explaining that WSL install fails inside a VM unless nested virtualization is enabled on the host. Includes the Hyper-V Set-VMProcessor command.