### PR TITLE
Detect existing WSL distros via wsl --list instead of HKCU\Lxss

### DIFF
--- a/src/windows-dev-config/README.md
+++ b/src/windows-dev-config/README.md
@@ -132,7 +132,7 @@ Package resources use `Microsoft.WinGet/Package` with `source: winget` and `useL
 | `ElevationCheck` | `Microsoft.DSC.Transitional/WindowsPowerShellScript` | `testScript` checks `IsInRole(Administrator)`. If false, `setScript` re-invokes `winget configure --file <this> --accept-configuration-agreements --disable-interactivity --wait` via `Start-Process -Verb RunAs`, then throws so the unelevated session ends cleanly. |
 | `InstallWslComponents` | `Microsoft.DSC.Transitional/WindowsPowerShellScript` | `testScript` probes for the `vmcompute` service (presence ⇒ Virtual Machine Platform is active). `setScript` runs `wsl --install --no-distribution`. |
 | `RebootForVmp` | `Microsoft.DSC.Transitional/WindowsPowerShellScript` | Same `vmcompute` test. `setScript` registers `HKCU:\...\RunOnce\DSCConfigureResume` with the same `winget configure --file <this> --accept-configuration-agreements` command, then `Restart-Computer -Force` and throws so DSC stops the current run. |
-| `InstallUbuntu` | `Microsoft.DSC.Transitional/WindowsPowerShellScript` | `testScript` checks for any subkey under `HKCU:\...\Lxss`. `setScript` runs `wsl --install -d Ubuntu --no-launch`. |
+| `InstallUbuntu` | `Microsoft.DSC.Transitional/WindowsPowerShellScript` | `testScript` runs `wsl --list --quiet` and returns true if any distro is already registered. `setScript` runs `wsl --install -d Ubuntu --no-launch`. |
 
 All app resources that need WSL present depend on `InstallUbuntu` so the OS work happens before the reboot — but the WSL install is still part of the same `winget configure` invocation thanks to the RunOnce resume.
 
@@ -273,7 +273,7 @@ HKLM policies, applied via `Microsoft.Windows/Registry`:
 | **`useLatest: true`** | Each run grabs the latest available version. Builds may differ between machines applying the config on different days. |
 | **HKLM registry keys** | Sudo, the Widget service policy, Edge policies, Remote Desktop, Long Paths, and Developer Mode all live in HKLM. The `ElevationCheck` gate guarantees the run is elevated; without it these would silently fail. |
 | **PowerToys AOT path** | `HKCU\...\Notifications\Settings\PowerToys\Enabled` targets a specific registry path that may change across PowerToys versions. |
-| **Idempotency of WSL phases** | `InstallWslComponents` and `RebootForVmp` both test for `vmcompute`. Re-running after the reboot is a no-op for those resources. `InstallUbuntu` tests for any `Lxss` subkey, so it skips once any distro is registered. |
+| **Idempotency of WSL phases** | `InstallWslComponents` and `RebootForVmp` both test for `vmcompute`. Re-running after the reboot is a no-op for those resources. `InstallUbuntu` queries `wsl --list --quiet`, so it skips once any distro is registered. |
 | **Pinned font release** | `InstallCascadiaCodeNerdFonts` hard-codes Cascadia Code release `2407.24` from `microsoft/cascadia-code`. Bump `$Version` to pick up newer releases. |
 | **Windows Terminal settings overwrite** | `SetCascadiaNfAsDefault` and `ps7default` rewrite `settings.json` via `ConvertTo-Json`. `SetCascadiaNfAsDefault` writes a `settings.json.bak` first; `ps7default` does not. JSON comments will not survive the round-trip. |
 | **`ohMyPoshProfileSet` runs `. $PROFILE`** | Dot-sourcing the profile inside `pwsh -NoProfile` can surface errors from the user's existing profile during DSC apply. |

--- a/src/windows-dev-config/dev-config.winget
+++ b/src/windows-dev-config/dev-config.winget
@@ -956,13 +956,34 @@ resources:
     - RebootForVmp
   properties:
     getScript: |
-      # WSL tracks installed distros as subkeys under Lxss.
-      $distros = Get-ChildItem 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss' -ErrorAction Ignore
-      return @{ distroCount = ($distros | Measure-Object).Count }
+      $env:WSL_UTF8 = '1'
+      $distros = @()
+      try {
+        $raw = & wsl.exe --list --quiet 2>$null
+        if ($LASTEXITCODE -eq 0 -and $raw) {
+          $distros = @($raw |
+            ForEach-Object { ($_ -replace "`0", '').Trim() } |
+            Where-Object { $_ })
+        }
+      } catch {
+        # wsl.exe not on PATH (e.g. WSL platform not yet installed). Treat as
+        # "no distros" and let setScript run.
+      }
+      return @{ distroCount = $distros.Count; distros = ($distros -join ',') }
     testScript: |
-      # Skip if any distro is already registered.
-      $distros = Get-ChildItem 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss' -ErrorAction Ignore
-      return [bool]$distros
+      $env:WSL_UTF8 = '1'
+      try {
+        $raw = & wsl.exe --list --quiet 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $raw) {
+          return $false
+        }
+        $distros = @($raw |
+          ForEach-Object { ($_ -replace "`0", '').Trim() } |
+          Where-Object { $_ })
+        return $distros.Count -gt 0
+      } catch {
+        return $false
+      }
     setScript: |
       Write-Host "InstallUbuntu: running wsl --install -d Ubuntu --no-launch..."
       $process = Start-Process -FilePath "cmd.exe" -ArgumentList "/c wsl --install -d Ubuntu --no-launch >nul 2>&1" -Wait -PassThru


### PR DESCRIPTION
 The InstallUbuntu resource previously checked HKCU:\...\Lxss to decide whether to install Ubuntu, but that registry path isn't reliably populated by newer wsl --install flows. The resource re-ran on machines that already had Ubuntu and failed.
 
 Switches testScript and getScript to query wsl --list --quiet. The check stays broad ("any distro present") to avoid installing Ubuntu over an existing Debian/Kali setup. README updated to match.
 
 Closes #48