### PR TITLE
Add SQL lightweight developer workload

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Three developer setups live in this repo. Pick the one that matches what you wan
 | --- | --- |
 | A complete dev workstation: tools, OS settings, WSL, and terminal. One command, may reboot. | [Windows Dev Config](#%EF%B8%8F-windows-dev-config) |
 | A polished WSL shell: zsh/bash, Starship, CLI tools, and a themed terminal profile. Interactive or unattended. | [WSL Comfort](#-wsl-comfort) |
-| A single language toolchain: Node, Python, .NET, Rust, Go, Java, PHP, WinForms, or WinUI 3. One command each. | [Workloads](#-single-language-workloads) |
+| A single language toolchain: Node, Python, SQL, .NET, Rust, Go, Java, PHP, WinForms, or WinUI 3. One command each. | [Workloads](#-single-language-workloads) |
 
 Most of them use [`winget configure`](https://learn.microsoft.com/en-us/windows/package-manager/winget/configure). If you've never used it before, enable it once:
 
@@ -136,6 +136,7 @@ Just want one toolchain? Pick a row. Each workload ships a `configuration.winget
 | Java       | Microsoft Build of OpenJDK 25 LTS                                       | `winget configure -f .\Workloads\java\configuration.winget --accept-configuration-agreements --disable-interactivity`       |
 | Rust       | Rust stable via rustup                                                  | `winget configure -f .\Workloads\rust\configuration.winget --accept-configuration-agreements --disable-interactivity`       |
 | Python     | Python 3.14 + uv                                                       | `winget configure -f .\Workloads\python\configuration.winget --accept-configuration-agreements --disable-interactivity`     |
+| SQL        | Lightweight SQL Developer: SQL Server + sqlcmd + VS Code extension     | `winget configure -f .\Workloads\sql\configuration.winget --accept-configuration-agreements --disable-interactivity`        |
 | WinForms   | .NET SDK 10 + Windows Forms desktop workload                            | `winget configure -f .\Workloads\winforms\configuration.winget --accept-configuration-agreements --disable-interactivity`   |
 | WinUI 3    | .NET SDK 10 + Visual Studio Community + Windows App SDK / WinUI 3 + WinAppCLI | `winget configure -f .\Workloads\winui\configuration.winget --accept-configuration-agreements --disable-interactivity` |
 

--- a/src/Workloads/sql/configuration.winget
+++ b/src/Workloads/sql/configuration.winget
@@ -27,7 +27,7 @@ resources:
   - name: VSCode
     type: Microsoft.WinGet/Package
     dependsOn:
-      - "[resourceId('Microsoft.WinGet/Package', 'PowerShell')]"
+      - PowerShell
     properties:
       id: Microsoft.VisualStudioCode
       source: winget
@@ -63,7 +63,7 @@ resources:
   - name: InstallVSCodeDscModule
     type: Microsoft.DSC.Transitional/PowerShellScript
     dependsOn:
-      - "[resourceId('Microsoft.WinGet/Package', 'PowerShell')]"
+      - PowerShell
     metadata:
       description: Install the Microsoft.VSCode.Dsc prerelease resource module
     properties:
@@ -84,8 +84,8 @@ resources:
   - name: SqlDatabaseProjectsVSCodeExtension
     type: Microsoft.VSCode.Dsc/VSCodeExtension
     dependsOn:
-      - "[resourceId('Microsoft.WinGet/Package', 'VSCode')]"
-      - "[resourceId('Microsoft.DSC.Transitional/PowerShellScript', 'InstallVSCodeDscModule')]"
+      - VSCode
+      - InstallVSCodeDscModule
     metadata:
       description: Install the SQL Database Projects VS Code extension
     properties:

--- a/src/Workloads/sql/configuration.winget
+++ b/src/Workloads/sql/configuration.winget
@@ -1,0 +1,93 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+#
+#     winget configure --file scripts/windows/sql/configuration.winget `
+#         --accept-configuration-agreements `
+#         --disable-interactivity
+#
+# Lightweight SQL developer workload: installs SQL Server Developer, sqlcmd,
+# VS Code, and the SQL database projects extension. It intentionally does not
+# install Visual Studio or SSDT tools.
+#
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+metadata:
+  winget:
+    processor: dscv3
+resources:
+  - name: PowerShell
+    type: Microsoft.WinGet/Package
+    properties:
+      id: Microsoft.PowerShell
+      source: winget
+      acceptAgreements: true
+    metadata:
+      description: Install PowerShell 7
+      winget:
+        securityContext: elevated
+
+  - name: VSCode
+    type: Microsoft.WinGet/Package
+    dependsOn:
+      - "[resourceId('Microsoft.WinGet/Package', 'PowerShell')]"
+    properties:
+      id: Microsoft.VisualStudioCode
+      source: winget
+      acceptAgreements: true
+    metadata:
+      description: Install Visual Studio Code
+      winget:
+        securityContext: elevated
+
+  - name: Sqlcmd
+    type: Microsoft.WinGet/Package
+    properties:
+      id: Microsoft.Sqlcmd
+      source: winget
+      acceptAgreements: true
+    metadata:
+      description: Install sqlcmd command-line tools
+      winget:
+        securityContext: elevated
+
+  - name: SQLServerDeveloper
+    type: Microsoft.WinGet/Package
+    properties:
+      id: Microsoft.SQLServer.2025.Developer
+      source: winget
+      acceptAgreements: true
+    metadata:
+      description: Install SQL Server 2025 Developer
+      winget:
+        securityContext: elevated
+
+  # TODO: When PowerShell 7+ ships Microsoft.PowerShell.PSResourceGet v1.3.0, change it for built-in DSC resource module.
+  - name: InstallVSCodeDscModule
+    type: Microsoft.DSC.Transitional/PowerShellScript
+    dependsOn:
+      - "[resourceId('Microsoft.WinGet/Package', 'PowerShell')]"
+    metadata:
+      description: Install the Microsoft.VSCode.Dsc prerelease resource module
+    properties:
+      getScript: |
+        $module = Get-InstalledPSResource -Name Microsoft.VSCode.Dsc -ErrorAction SilentlyContinue |
+          Where-Object { $_.Version.ToString() -eq '0.1.5-alpha' } |
+          Select-Object -First 1
+        $version = if ($module) { $module.Version.ToString() } else { $null }
+        return @{ installed = [bool]$module; version = $version }
+      testScript: |
+        $module = Get-InstalledPSResource -Name Microsoft.VSCode.Dsc -ErrorAction SilentlyContinue |
+          Where-Object { $_.Version.ToString() -eq '0.1.5-alpha' } |
+          Select-Object -First 1
+        return [bool]$module
+      setScript: |
+        Install-PSResource -Name Microsoft.VSCode.Dsc -Version 0.1.5-alpha -Prerelease -Repository PSGallery -TrustRepository -AcceptLicense -Scope CurrentUser
+
+  - name: SqlDatabaseProjectsVSCodeExtension
+    type: Microsoft.VSCode.Dsc/VSCodeExtension
+    dependsOn:
+      - "[resourceId('Microsoft.WinGet/Package', 'VSCode')]"
+      - "[resourceId('Microsoft.DSC.Transitional/PowerShellScript', 'InstallVSCodeDscModule')]"
+    metadata:
+      description: Install the SQL Database Projects VS Code extension
+    properties:
+      Name: ms-mssql.sql-database-projects-vscode
+      Exist: true

--- a/src/Workloads/sql/configuration.winget
+++ b/src/Workloads/sql/configuration.winget
@@ -69,17 +69,17 @@ resources:
     properties:
       getScript: |
         $module = Get-InstalledPSResource -Name Microsoft.VSCode.Dsc -ErrorAction SilentlyContinue |
-          Where-Object { $_.Version.ToString() -eq '0.1.5-alpha' } |
+          Where-Object { $_.Version.ToString() -eq '0.1.6-alpha' -and $_.PrivateData.PSData.Prerelease -eq 'alpha' } |
           Select-Object -First 1
         $version = if ($module) { $module.Version.ToString() } else { $null }
         return @{ installed = [bool]$module; version = $version }
       testScript: |
         $module = Get-InstalledPSResource -Name Microsoft.VSCode.Dsc -ErrorAction SilentlyContinue |
-          Where-Object { $_.Version.ToString() -eq '0.1.5-alpha' } |
+          Where-Object { $_.Version.ToString() -eq '0.1.6-alpha' -and $_.PrivateData.PSData.Prerelease -eq 'alpha' } |
           Select-Object -First 1
         return [bool]$module
       setScript: |
-        Install-PSResource -Name Microsoft.VSCode.Dsc -Version 0.1.5-alpha -Prerelease -Repository PSGallery -TrustRepository -AcceptLicense -Scope CurrentUser
+        Install-PSResource -Name Microsoft.VSCode.Dsc -Version 0.1.6-alpha -Prerelease -Repository PSGallery -TrustRepository -AcceptLicense -Scope CurrentUser
 
   - name: SqlDatabaseProjectsVSCodeExtension
     type: Microsoft.VSCode.Dsc/VSCodeExtension

--- a/src/Workloads/sql/install.ps1
+++ b/src/Workloads/sql/install.ps1
@@ -1,0 +1,21 @@
+<#
+.SYNOPSIS
+  Apply the SQL winget DSC configuration on Windows.
+
+.DESCRIPTION
+  This script is a thin CI/dev shim. The core artifact for the SQL flow is
+  `configuration.winget` in this directory - a winget DSC configuration that
+  installs SQL Server Developer, sqlcmd, VS Code, and the SQL Database Projects
+  extension without installing Visual Studio or SSDT.
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+& (Join-Path $PSScriptRoot '..\_common\apply-configuration.ps1') `
+    -Id              'sql' `
+    -ConfigFile      (Join-Path $PSScriptRoot 'configuration.winget') `
+    -RequireCommands @('sqlcmd', 'code')

--- a/src/docs/development.md
+++ b/src/docs/development.md
@@ -44,6 +44,7 @@ extension.
 | Java              | ✅ automated   | `Microsoft.OpenJDK.25`                                                                  |
 | Rust              | ✅ automated   | `Rustlang.Rustup` (then `rustup default stable`)                                        |
 | Python            | ✅ automated   | `Python.Python.3.14`, `astral-sh.uv`                                                    |
+| SQL Developer     | 🙋 manual     | Lightweight SQL Developer: SQL Server + sqlcmd + VS Code extension; no VS/SSDT           |
 | WinForms          | 🙋 manual     | `Microsoft.DotNet.SDK.10` + the .NET desktop workload (multi-GB; manual to spare CI minutes) |
 | WinUI 3           | 🙋 manual     | `Microsoft.DotNet.SDK.10`, `Microsoft.VisualStudio.Community`, `Microsoft.WinAppCLI` + WinUI/Universal/ManagedDesktop VS workloads |
 | Calm OS           | 🙋 manual     | A full distraction-free workstation: apps + ~24 registry tweaks + WSL + Ubuntu (see [`windows-dev-config/README.md`](../windows-dev-config/README.md)) |

--- a/src/manifest.yml
+++ b/src/manifest.yml
@@ -223,6 +223,25 @@ flows:
       expected: src/tests/python/expected.txt
       version: "python --version; uv --version"
 
+  - id: sql
+    name: Lightweight SQL Developer
+    description: SQL Server Developer + sqlcmd + VS Code SQL database projects extension
+    category: languages
+    tags: [sql, sqlserver, sqlcmd, database, vscode]
+    icon: 🗄️
+    onboardingUrl: https://learn.microsoft.com/sql/sql-server/
+    # Installs full SQL Server Developer, so keep it out of automated CI even
+    # though the workload intentionally avoids Visual Studio and SSDT.
+    manual_test: true
+    os: [windows]
+    windows:
+      install: Workloads/sql/install.ps1
+      configuration: Workloads/sql/configuration.winget
+      build: ""
+      run: pwsh -NoProfile -File src/tests/sql/probe.ps1
+      expected: src/tests/sql/expected.txt
+      version: "sqlcmd --version; code --version"
+
   - id: comfort-shell
     name: Comfort Shell
     description: Cozy WSL shell setup — zsh/bash, starship, modern CLI tools, and shims

--- a/src/tests/sql/expected.txt
+++ b/src/tests/sql/expected.txt
@@ -1,0 +1,1 @@
+Hello, SQL developer!

--- a/src/tests/sql/probe.ps1
+++ b/src/tests/sql/probe.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+foreach ($commandName in @('sqlcmd', 'code')) {
+    if (-not (Get-Command $commandName -ErrorAction SilentlyContinue)) {
+        throw "$commandName was not found on PATH."
+    }
+}
+
+Write-Output 'Hello, SQL developer!'


### PR DESCRIPTION
Add a new lightweight SQL developer workload for Windows. It focuses on VS Code instead of VS or SSDT.