### PR TITLE
Add Microsoft.Coreutils to windows-dev-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ winget configure -f .\windows-dev-config\dev-config.winget --accept-configuratio
 <details>
 <summary><strong>What you get</strong></summary>
 
-- **Dev tools:** PowerShell 7, Git, GitHub CLI, VS Code, .NET SDK 10, Python 3.14 + uv, Node.js, Oh My Posh, and PowerToys.
+- **Dev tools:** PowerShell 7, Git, GitHub CLI, VS Code, .NET SDK 10, Python 3.14 + uv, Node.js, Coreutils for Windows, Oh My Posh, and PowerToys.
 - **Terminal:** PowerShell 7 is the default profile, Oh My Posh is enabled, and Cascadia Mono NF is set as the default font.
 - **Windows settings:** Dark theme, developer mode, long paths, File Explorer defaults, Start/Search cleanup, Edge policies, and other workstation defaults.
 - **WSL:** WSL platform + Ubuntu, including the reboot and the `RunOnce` resume step.

--- a/src/windows-dev-config/README.md
+++ b/src/windows-dev-config/README.md
@@ -105,7 +105,7 @@ The configuration is idempotent, so it is safe to re-run after reboot or at any 
 
 ## What this configures
 
-- **13 apps** via winget (PowerShell 7, Git, GitHub CLI, GitHub Copilot CLI, VS Code, .NET SDK 10, Python 3.14, UV, Node.js LTS, NVM for Windows, Windows Application CLI, plus optional Oh My Posh and PowerToys).
+- **14 apps** via winget (PowerShell 7, Git, GitHub CLI, GitHub Copilot CLI, VS Code, .NET SDK 10, Python 3.14, UV, Node.js LTS, NVM for Windows, Coreutils for Windows, Windows Application CLI, plus optional Oh My Posh and PowerToys).
 - **WSL + Ubuntu**, installed via 3 transitional script resources that bracket a reboot (Phase 2/3/4 below).
 - **~24 registry settings** for theme/OS, Explorer, Taskbar, Search, Start, Notifications, Edge, Sudo, and the Widget service.
 - **Cascadia Code & Cascadia Mono Nerd Fonts** downloaded from the `microsoft/cascadia-code` GitHub release and registered per-user.
@@ -150,6 +150,7 @@ All app resources that need WSL present depend on `InstallUbuntu` so the OS work
 | `UV` | `astral-sh.uv` | |
 | `NodeJS` | `OpenJS.NodeJS.LTS` | Pinned to the LTS line (currently Node 24 LTS). |
 | `nvmForNode` | `CoreyButler.NVMforWindows` | Node version manager for Windows. |
+| `Coreutils` | `Microsoft.Coreutils` | Microsoft-maintained Coreutils for Windows. Command integration is handled by the package itself after install. |
 | `OhMyPosh` | `JanDeDobbeleer.OhMyPosh` | Marked Optional in the comments. Triggers `ohMyPoshProfileSet`. |
 | `winappCli` | `Microsoft.winappcli` | Windows Application CLI. |
 | `PowerToys` | `Microsoft.PowerToys` | Marked Optional. Followed by `PowerToysAOT` which disables AOT notifications via registry. |

--- a/src/windows-dev-config/dev-config.winget
+++ b/src/windows-dev-config/dev-config.winget
@@ -710,6 +710,16 @@ resources:
     securityContext: elevated
 
 - type: Microsoft.WinGet/Package
+  name: Coreutils
+  properties:
+    id: Microsoft.Coreutils
+    source: winget
+    useLatest: true
+  metadata:
+    description: Install Coreutils for Windows
+    securityContext: elevated
+
+- type: Microsoft.WinGet/Package
   name: OhMyPosh
   properties:
     id: JanDeDobbeleer.OhMyPosh


### PR DESCRIPTION
`windows-dev-config` already provisions a baseline set of developer-facing CLI
tools such as Git, GitHub CLI, PowerShell, Node.js, Python, and WinAppCLI.

`Microsoft.Coreutils` fits the same layer and improves native Windows command-line
ergonomics while helping align workflows across Windows, WSL, Linux, and macOS.

PowerShell command integration is handled by Microsoft Coreutils itself after install.

closes #72 