### PR TITLE
Fix normalize output function

### DIFF
--- a/src/tests/_harness/run-flow.ps1
+++ b/src/tests/_harness/run-flow.ps1
@@ -48,8 +48,8 @@ function Normalize-Output {
     if ($null -eq $Text) { return '' }
     $Text = $Text -replace "`r`n", "`n"
     $Text = $Text -replace "`r",   "`n"
-    $lines = $Text -split "`n"
-    $lines = $lines | ForEach-Object { $_.TrimEnd() }
+    $lines = @($Text -split "`n")
+    $lines = @($lines | ForEach-Object { $_.TrimEnd() })
     # Trim trailing blank lines.
     $i = $lines.Count - 1
     while ($i -ge 0 -and [string]::IsNullOrEmpty($lines[$i])) { $i-- }


### PR DESCRIPTION
This pull request makes a small change to the `Normalize-Output` function in `src/tests/_harness/run-flow.ps1` to ensure that the `$lines` variable is always an array, even when the input is empty or contains a single line. This improves consistency and prevents potential issues with variable types.