### PR TITLE
Update OhMyPosh command for PowerShell initialization

### DIFF
--- a/src/windows-dev-config/dev-config.winget
+++ b/src/windows-dev-config/dev-config.winget
@@ -934,7 +934,7 @@ resources:
   properties:
     states:
       - name: pwsh
-        command: oh-my-posh init pwsh
+        command: $(if (Get-Command 'oh-my-posh' -ErrorAction SilentlyContinue) { oh-my-posh init pwsh })
   metadata:
     description: Setup OhMyPosh in PowerShell 7
 


### PR DESCRIPTION
Oh my posh dsc adds in the `| Invoke Expression`  Adding the wrapper check needed a bit of TLC to be well formed

<img width="1206" height="633" alt="image" src="https://github.com/user-attachments/assets/6e03857a-0684-40de-881a-07a1d055f97f" />

and after uninstall
<img width="1212" height="362" alt="image" src="https://github.com/user-attachments/assets/5be86142-fae1-49d9-999c-e5c17aa642c3" />

zero errors