### PR TITLE
Enhance OhMyPosh command with UTF-8 encoding

### DIFF
--- a/src/windows-dev-config/dev-config.winget
+++ b/src/windows-dev-config/dev-config.winget
@@ -934,7 +934,14 @@ resources:
   properties:
     states:
       - name: pwsh
-        command: $(if (Get-Command 'oh-my-posh' -ErrorAction SilentlyContinue) { oh-my-posh init pwsh })
+        command: |
+          $(if (Get-Command 'oh-my-posh' -ErrorAction SilentlyContinue) { 
+            oh-my-posh init pwsh
+            # Set output encoding to UTF-8
+            [Console]::OutputEncoding =[System.Text.Encoding]::UTF8
+            # Set input encoding to UTF-8 (for reading user input with non-ASCII chars)
+            [Console]::InputEncoding =[System.Text.Encoding]::UTF8
+          })
   metadata:
     description: Setup OhMyPosh in PowerShell 7
 


### PR DESCRIPTION
Updated the command for OhMyPosh initialization to include UTF-8 encoding settings.

repo: type "hello world" and then delete to after "hell".  you'll get the issue below.

without
<img width="881" height="304" alt="image" src="https://github.com/user-attachments/assets/ec7f9518-bbad-4004-98f0-889d2e96cce1" />

with
<img width="1012" height="559" alt="image" src="https://github.com/user-attachments/assets/f9239bd0-e3c2-4076-bac9-abe0974077a5" />
