### PR TITLE
fix(dev-config): Use skipExistingInit to prevent overwriting existing oh-my-posh config

### DIFF
--- a/src/windows-dev-config/dev-config.winget
+++ b/src/windows-dev-config/dev-config.winget
@@ -942,6 +942,7 @@ resources:
             # Set input encoding to UTF-8 (for reading user input with non-ASCII chars)
             [Console]::InputEncoding =[System.Text.Encoding]::UTF8
           })
+        skipExistingInit: true
   metadata:
     description: Setup OhMyPosh in PowerShell 7
 

--- a/windows-dev-config/dev-config.winget
+++ b/windows-dev-config/dev-config.winget
@@ -942,6 +942,7 @@ resources:
             # Set input encoding to UTF-8 (for reading user input with non-ASCII chars)
             [Console]::InputEncoding =[System.Text.Encoding]::UTF8
           })
+        skipExistingInit: true
   metadata:
     description: Setup OhMyPosh in PowerShell 7
 


### PR DESCRIPTION
Fixes #53 

### Issue

In `windows-dev-config/dev-config.winget`, the config uses:

```yaml
- type: OhMyPosh/Shell
  name: ohMyPoshProfileSet
  dependsOn:
    - OhMyPosh
  properties:
    states:
      - name: pwsh
        command: oh-my-posh init pwsh
```

When DSC is applied, it updates the existing `oh-my-posh` init line in `$PROFILE` to the declared command.

That means a custom line like:

```powershell
oh-my-posh init pwsh --config "$HOME\.config\oh-my-posh\M365Princess.omp.json" | Invoke-Expression
```

gets rewritten to:

```powershell
oh-my-posh init pwsh | Invoke-Expression
```

### Why this is a problem

Many users customize their prompt via `--config`, and this is valid/manual user configuration. The rest of the profile remains untouched, but the `oh-my-posh` line is normalized and the custom theme/config is lost.

### Fix

Thanks to the [upstream improvement](https://github.com/JanDeDobbeleer/oh-my-posh/pull/7563), oh-my-posh DSC module now have a feature to skip the update when there's existing configuration. 

With this, we can simply fix the issue like this:

```yaml
- type: OhMyPosh/Shell
  name: ohMyPoshProfileSet
  dependsOn:
    - OhMyPosh
  properties:
    states:
      - name: pwsh
        command: oh-my-posh init pwsh
        skipExistingInit: true
```