### PR TITLE
Update all dependencies and components; add workload undo script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       manual_count:  ${{ steps.plan.outputs.manual_count }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Plan matrices from manifest.yml
         id: plan
@@ -132,7 +132,7 @@ jobs:
       FLOW_VERSION:  ${{ matrix.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Preflight
         shell: pwsh
@@ -207,7 +207,7 @@ jobs:
 
       - name: Upload diagnostics on failure
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-${{ matrix.id }}-diagnostics
           path: diagnostics/
@@ -235,7 +235,7 @@ jobs:
       FLOW_VERSION:  ${{ matrix.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install flow (${{ matrix.id }})
         shell: bash

--- a/.github/workflows/signed-copy-guard.yml
+++ b/.github/workflows/signed-copy-guard.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -151,7 +151,7 @@ jobs:
 
       - name: Upload drift report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: signed-copy-drift-report
           path: drift-report.json

--- a/src/Workloads/undo.ps1
+++ b/src/Workloads/undo.ps1
@@ -283,6 +283,7 @@ function Remove-ScriptAnalyzerSettings {
     if (Test-Path -LiteralPath $settingsPath) {
         Invoke-Step 'remove powershell.scriptAnalysis.* keys from VS Code settings.json' {
             $raw = Get-Content -LiteralPath $settingsPath -Raw
+            if ([string]::IsNullOrWhiteSpace($raw)) { return }
             $clean = [regex]::Replace($raw, '/\*[\s\S]*?\*/', '')
             $clean = [regex]::Replace($clean, '(?m)^\s*//.*$', '')
             if ([string]::IsNullOrWhiteSpace($clean)) { return }

--- a/src/Workloads/undo.ps1
+++ b/src/Workloads/undo.ps1
@@ -1,0 +1,380 @@
+<#
+.SYNOPSIS
+  Undo (uninstall) a workload previously applied via its configuration.winget.
+
+.DESCRIPTION
+  Best-effort reversal of the winget DSC configurations under src/Workloads.
+  For the selected workload it:
+    * reverses the RunCommandOnSet / script extras first (npm global
+      typescript, rustup toolchains, VS Code extensions, PSScriptAnalyzer
+      settings, Visual Studio workloads),
+    * then uninstalls the winget packages the configuration installed.
+
+  Components shared by several workloads (PowerShell 7, VS Code, .NET SDK 10,
+  Visual Studio Community, the Microsoft.VSCode.Dsc module) are kept by
+  default so undoing one workload does not break another. Pass -IncludeShared
+  to remove those too.
+
+  winget DSC has no "unset", so this script mirrors each configuration by
+  hand. Keep it in sync when a configuration.winget changes.
+
+.PARAMETER Workload
+  Workload to undo, or 'all' for every workload.
+
+.PARAMETER IncludeShared
+  Also uninstall components shared across workloads.
+
+.EXAMPLE
+  pwsh -File src/Workloads/undo.ps1 -Workload typescript
+
+.EXAMPLE
+  pwsh -File src/Workloads/undo.ps1 -Workload all -IncludeShared -WhatIf
+#>
+
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('typescript', 'php', 'python', 'dotnet', 'go', 'java',
+                 'rust', 'sql', 'powershell', 'winforms', 'winui', 'all')]
+    [string] $Workload,
+
+    [switch] $IncludeShared
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# ---------------------------------------------------------------------------
+# Undo table. One entry per workload, mirroring its configuration.winget.
+#   packages    : winget package ids to uninstall, in reverse install order.
+#                 shared = $true is skipped unless -IncludeShared.
+#   pre         : script blocks run before package uninstalls (undo the
+#                 RunCommandOnSet / PowerShellScript extras).
+#   vsWorkloads : Visual Studio workload/component ids to remove from the
+#                 given product when the product itself is kept.
+# ---------------------------------------------------------------------------
+$undoTable = [ordered]@{
+    typescript = @{
+        pre = @(
+            {
+                if (Get-Command npm -ErrorAction SilentlyContinue) {
+                    Invoke-Step "npm uninstall --global typescript" {
+                        & npm uninstall --global --no-fund --no-audit typescript
+                    }
+                }
+            }
+        )
+        packages = @(
+            @{ id = 'OpenJS.NodeJS.LTS' }
+        )
+    }
+    php = @{
+        packages = @(
+            @{ id = 'PHP.PHP.8.5' }
+        )
+    }
+    python = @{
+        packages = @(
+            @{ id = 'astral-sh.uv' }
+            @{ id = 'Python.Python.3.14' }
+        )
+    }
+    dotnet = @{
+        packages = @(
+            @{ id = 'Microsoft.DotNet.SDK.10'; shared = $true }
+        )
+    }
+    go = @{
+        packages = @(
+            @{ id = 'GoLang.Go' }
+        )
+    }
+    java = @{
+        packages = @(
+            @{ id = 'Microsoft.OpenJDK.25' }
+        )
+    }
+    rust = @{
+        pre = @(
+            {
+                # `rustup self uninstall` removes ~/.cargo and ~/.rustup; the
+                # winget uninstall below then clears the package registration.
+                if (Get-Command rustup -ErrorAction SilentlyContinue) {
+                    Invoke-Step "rustup self uninstall" {
+                        & rustup self uninstall -y
+                    }
+                }
+            }
+        )
+        packages = @(
+            @{ id = 'Rustlang.Rustup' }
+            # Installed by the rust flow to provide MSVC link.exe; heavyweight
+            # and potentially useful to other tooling, so treated as shared.
+            @{ id = 'Microsoft.VisualStudio.2022.BuildTools'; shared = $true }
+        )
+    }
+    sql = @{
+        pre = @(
+            { Remove-VSCodeExtension 'ms-mssql.sql-database-projects-vscode' }
+            { Remove-VSCodeDscModule }
+        )
+        packages = @(
+            @{ id = 'Microsoft.SQLServer.2025.Developer' }
+            @{ id = 'Microsoft.Sqlcmd' }
+            @{ id = 'Microsoft.VisualStudioCode'; shared = $true }
+            @{ id = 'Microsoft.PowerShell'; shared = $true }
+        )
+    }
+    powershell = @{
+        pre = @(
+            { Remove-VSCodeExtension 'ms-vscode.powershell' }
+            { Remove-VSCodeExtension 'pspester.pester-test' }
+            { Remove-ScriptAnalyzerSettings }
+            { Remove-VSCodeDscModule }
+        )
+        packages = @(
+            @{ id = 'Microsoft.VisualStudioCode'; shared = $true }
+            @{ id = 'Microsoft.PowerShell'; shared = $true }
+        )
+    }
+    winforms = @{
+        vsWorkloads = @{
+            channelId = 'VisualStudio.18.Release'
+            productId = 'Microsoft.VisualStudio.Product.Community'
+            ids       = @('Microsoft.VisualStudio.Workload.ManagedDesktop')
+        }
+        packages = @(
+            @{ id = 'Microsoft.VisualStudio.Community'; shared = $true }
+            @{ id = 'Microsoft.DotNet.SDK.10'; shared = $true }
+            @{ id = 'Microsoft.PowerShell'; shared = $true }
+        )
+    }
+    winui = @{
+        vsWorkloads = @{
+            channelId = 'VisualStudio.18.Release'
+            productId = 'Microsoft.VisualStudio.Product.Community'
+            ids       = @(
+                'Microsoft.VisualStudio.Workload.ManagedDesktop'
+                'Microsoft.VisualStudio.Workload.Universal'
+                'Microsoft.VisualStudio.ComponentGroup.WindowsAppSDK.Cs'
+            )
+        }
+        packages = @(
+            @{ id = 'Microsoft.WindowsAppRuntime.1.8' }
+            @{ id = 'Microsoft.WinAppCLI' }
+            @{ id = 'Microsoft.VisualStudio.Community'; shared = $true }
+            @{ id = 'Microsoft.DotNet.SDK.10'; shared = $true }
+            @{ id = 'Microsoft.PowerShell'; shared = $true }
+        )
+    }
+}
+
+# Workloads whose configurations reference each shared component. Used to
+# warn when -IncludeShared removes something another workload may still need.
+$sharedUsers = @{
+    'Microsoft.PowerShell'                    = @('powershell', 'sql', 'winforms', 'winui')
+    'Microsoft.VisualStudioCode'              = @('powershell', 'sql')
+    'Microsoft.DotNet.SDK.10'                 = @('dotnet', 'winforms', 'winui')
+    'Microsoft.VisualStudio.Community'        = @('winforms', 'winui')
+    'Microsoft.VisualStudio.2022.BuildTools'  = @('rust')
+}
+
+$script:failures = @()
+
+function Invoke-Step {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)] [string] $Description,
+        [Parameter(Mandatory)] [scriptblock] $Action
+    )
+    if (-not $PSCmdlet.ShouldProcess($Description)) { return }
+    Write-Host ">> $Description"
+    try {
+        $global:LASTEXITCODE = 0
+        & $Action
+        if ((Test-Path variable:LASTEXITCODE) -and $LASTEXITCODE -ne 0) {
+            throw "exit code $LASTEXITCODE"
+        }
+    } catch {
+        Write-Warning "FAILED: $Description — $_"
+        $script:failures += $Description
+    }
+}
+
+function Test-WingetPackageInstalled {
+    param([Parameter(Mandatory)] [string] $Id)
+    & winget list --id $Id --exact --source winget --disable-interactivity `
+        --accept-source-agreements *> $null
+    return ($LASTEXITCODE -eq 0)
+}
+
+function Remove-WingetPackage {
+    param(
+        [Parameter(Mandatory)] [string] $Id,
+        [bool] $Shared = $false
+    )
+    if ($Shared -and -not $IncludeShared) {
+        $users = $sharedUsers[$Id] -join ', '
+        Write-Host "-- keeping shared package $Id (used by: $users); pass -IncludeShared to remove"
+        return
+    }
+    if (-not (Test-WingetPackageInstalled -Id $Id)) {
+        Write-Host "-- $Id not installed; skipping"
+        return
+    }
+    if ($Shared) {
+        $users = $sharedUsers[$Id] -join ', '
+        Write-Warning "$Id is shared by workloads: $users — removing because -IncludeShared was set"
+    }
+    Invoke-Step "winget uninstall $Id" {
+        & winget uninstall --id $Id --exact --silent `
+            --disable-interactivity --accept-source-agreements
+    }
+}
+
+function Remove-VSCodeExtension {
+    param([Parameter(Mandatory)] [string] $Name)
+    if (-not (Get-Command code -ErrorAction SilentlyContinue)) {
+        Write-Host "-- VS Code not on PATH; skipping extension $Name"
+        return
+    }
+    $installed = @(& code --list-extensions 2>$null)
+    if ($installed -notcontains $Name) {
+        Write-Host "-- VS Code extension $Name not installed; skipping"
+        return
+    }
+    Invoke-Step "code --uninstall-extension $Name" {
+        & code --uninstall-extension $Name
+    }
+}
+
+function Remove-VSCodeDscModule {
+    # Shared helper module installed by the powershell and sql workloads.
+    if (-not $IncludeShared) {
+        Write-Host '-- keeping shared module Microsoft.VSCode.Dsc (used by: powershell, sql); pass -IncludeShared to remove'
+        return
+    }
+    if (-not (Get-Command Get-InstalledPSResource -ErrorAction SilentlyContinue)) {
+        Write-Host '-- PSResourceGet not available; skipping Microsoft.VSCode.Dsc removal'
+        return
+    }
+    if (-not (Get-InstalledPSResource -Name Microsoft.VSCode.Dsc -ErrorAction SilentlyContinue)) {
+        Write-Host '-- Microsoft.VSCode.Dsc module not installed; skipping'
+        return
+    }
+    Invoke-Step 'Uninstall-PSResource Microsoft.VSCode.Dsc' {
+        Uninstall-PSResource -Name Microsoft.VSCode.Dsc -Scope CurrentUser
+    }
+}
+
+function Remove-ScriptAnalyzerSettings {
+    # Reverses ConfigurePowerShellScriptAnalyzer in powershell/configuration.winget:
+    # deletes PSScriptAnalyzerSettings.psd1 and the two settings.json keys.
+    $userDirectory = Join-Path $env:APPDATA 'Code\User'
+    $settingsPath = Join-Path $userDirectory 'settings.json'
+    $analyzerSettingsPath = Join-Path $userDirectory 'PSScriptAnalyzerSettings.psd1'
+
+    if (Test-Path -LiteralPath $analyzerSettingsPath) {
+        Invoke-Step "remove $analyzerSettingsPath" {
+            Remove-Item -LiteralPath $analyzerSettingsPath -Force
+        }
+    }
+
+    if (Test-Path -LiteralPath $settingsPath) {
+        Invoke-Step 'remove powershell.scriptAnalysis.* keys from VS Code settings.json' {
+            $raw = Get-Content -LiteralPath $settingsPath -Raw
+            $clean = [regex]::Replace($raw, '/\*[\s\S]*?\*/', '')
+            $clean = [regex]::Replace($clean, '(?m)^\s*//.*$', '')
+            if ([string]::IsNullOrWhiteSpace($clean)) { return }
+            $settings = $clean | ConvertFrom-Json -AsHashtable
+            $settings.Remove('powershell.scriptAnalysis.enable')
+            $settings.Remove('powershell.scriptAnalysis.settingsPath')
+            $settings | ConvertTo-Json -Depth 100 |
+                Set-Content -LiteralPath $settingsPath -Encoding utf8
+        }
+    }
+}
+
+function Remove-VSWorkloads {
+    param([Parameter(Mandatory)] [hashtable] $Spec)
+
+    # When the VS product itself is being removed, dropping individual
+    # workloads first is pointless.
+    if ($IncludeShared) {
+        Write-Host '-- skipping per-workload VS modify; Visual Studio itself will be uninstalled'
+        return
+    }
+
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+    $setup   = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\setup.exe'
+    if (-not (Test-Path $vswhere) -or -not (Test-Path $setup)) {
+        Write-Host '-- Visual Studio Installer not found; skipping VS workload removal'
+        return
+    }
+    $installPath = & $vswhere -latest -products * -property installationPath
+    if (-not $installPath) {
+        Write-Host '-- no Visual Studio installation found; skipping VS workload removal'
+        return
+    }
+
+    $removeArgs = @('modify', '--installPath', $installPath,
+                    '--channelId', $Spec.channelId,
+                    '--productId', $Spec.productId)
+    foreach ($id in $Spec.ids) { $removeArgs += @('--remove', $id) }
+    $removeArgs += @('--quiet', '--norestart', '--wait')
+
+    Invoke-Step "VS setup.exe modify --remove $($Spec.ids -join ', ')" {
+        & $setup @removeArgs
+        # 3010 = success, reboot required.
+        if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 3010) {
+            throw "setup.exe exited with code $LASTEXITCODE"
+        }
+        $global:LASTEXITCODE = 0
+    }
+}
+
+function Invoke-WorkloadUndo {
+    param([Parameter(Mandatory)] [string] $Id)
+
+    $spec = $undoTable[$Id]
+    Write-Host ''
+    Write-Host "=== Undo workload: $Id ==="
+
+    if ($spec.Contains('pre')) {
+        foreach ($step in $spec.pre) { & $step }
+    }
+    if ($spec.Contains('vsWorkloads')) {
+        Remove-VSWorkloads -Spec $spec.vsWorkloads
+    }
+    foreach ($pkg in $spec.packages) {
+        $isShared = $pkg.Contains('shared') -and $pkg.shared
+        Remove-WingetPackage -Id $pkg.id -Shared $isShared
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    throw 'winget not found on PATH; cannot undo workload installs.'
+}
+
+$principal = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Warning 'Not running elevated; machine-scope uninstalls may fail. Re-run from an elevated shell if steps fail.'
+}
+
+$targets = @($Workload)
+if ($Workload -eq 'all') { $targets = @($undoTable.Keys) }
+
+foreach ($id in $targets) {
+    Invoke-WorkloadUndo -Id $id
+}
+
+Write-Host ''
+if ($script:failures.Count -gt 0) {
+    Write-Warning "Completed with $($script:failures.Count) failed step(s):"
+    $script:failures | ForEach-Object { Write-Warning "  - $_" }
+    exit 1
+}
+Write-Host "UNDO_OK: $($targets -join ', ')"

--- a/src/Workloads/winforms/configuration.winget
+++ b/src/Workloads/winforms/configuration.winget
@@ -89,7 +89,7 @@ resources:
       id: Microsoft.VisualStudio.Community
       source: winget
       acceptAgreements: true
-      version: 18.4.3
+      version: 18.8.2
     metadata:
       description: Install Visual Studio Community Edition for WinForms development
       winget:

--- a/src/Workloads/winui/configuration.winget
+++ b/src/Workloads/winui/configuration.winget
@@ -89,7 +89,7 @@ resources:
       id: Microsoft.VisualStudio.Community
       source: winget
       acceptAgreements: true
-      version: 18.4.3
+      version: 18.8.2
     metadata:
       description: Install Visual Studio 2026 Community
       winget:
@@ -109,11 +109,11 @@ resources:
   - type: Microsoft.WinGet/Package
     name: WindowsAppRuntime
     properties:
-      id: Microsoft.WindowsAppRuntime.1.6
+      id: Microsoft.WindowsAppRuntime.1.8
       source: winget
       acceptAgreements: true
     metadata:
-      description: Install the Windows App Runtime 1.6
+      description: Install the Windows App Runtime 1.8
       winget:
         securityContext: elevated
 

--- a/src/future/cmdpal/QuickWingetSetup/Directory.Packages.props
+++ b/src/future/cmdpal/QuickWingetSetup/Directory.Packages.props
@@ -3,17 +3,17 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.9.260303001" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0-preview.24508.2" />
-    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2903.40" />
-    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.183" />
-    <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4188" />
-    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools.MSIX" Version="1.7.20250829.1" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.260209005" />
-    <PackageVersion Include="Shmuelie.WinRTServer" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.11.260520004" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302" />
+    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.4129.50" />
+    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.298" />
+    <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.3.1" />
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.8249" />
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools.MSIX" Version="1.7.260610101" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.260710003" />
+    <PackageVersion Include="Shmuelie.WinRTServer" Version="2.2.1" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.8" />
-    <PackageVersion Include="YamlDotNet" Version="16.2.1" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.18" />
+    <PackageVersion Include="YamlDotNet" Version="18.1.0" />
   </ItemGroup>
 </Project>

--- a/src/future/cmdpal/QuickWingetSetup/QuickWingetSetup/QuickWingetSetup.csproj
+++ b/src/future/cmdpal/QuickWingetSetup/QuickWingetSetup/QuickWingetSetup.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>QuickWingetSetup</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
 
-    <WindowsSdkPackageVersion>10.0.26100.68-preview</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.26100.87</WindowsSdkPackageVersion>
     <TargetFramework>net9.0-windows10.0.26100.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>

--- a/src/tests/winui/hello.csproj
+++ b/src/tests/winui/hello.csproj
@@ -15,6 +15,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250205002" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260710003" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Dependency updates

All edits are confined to `src/` (top-level signed copies are left to the sign pipeline) plus the two workflows.

### QuickWingetSetup (cmdpal extension) — `src/future/cmdpal/QuickWingetSetup/`
| Package | From | To |
| --- | --- | --- |
| Microsoft.CommandPalette.Extensions | 0.9.260303001 | 0.11.260520004 |
| Microsoft.CodeAnalysis.NetAnalyzers | 9.0.0-preview.24508.2 | 10.0.302 |
| Microsoft.Web.WebView2 | 1.0.2903.40 | 1.0.4129.50 |
| Microsoft.Windows.CsWin32 | 0.3.183 | 0.3.298 |
| Microsoft.Windows.CsWinRT | 2.2.0 | 2.3.1 |
| Microsoft.Windows.SDK.BuildTools | 10.0.26100.4188 | 10.0.26100.8249 |
| Microsoft.Windows.SDK.BuildTools.MSIX | 1.7.20250829.1 | 1.7.260610101 |
| Microsoft.WindowsAppSDK | 1.8.260209005 | 1.8.260710003 |
| Shmuelie.WinRTServer | 2.1.1 | 2.2.1 |
| System.Text.Json | 9.0.8 | 9.0.18 |
| YamlDotNet | 16.2.1 | 18.1.0 |
| WindowsSdkPackageVersion | 10.0.26100.68-preview | 10.0.26100.87 (stable) |

### Workloads & tests
- **winui test project**: Microsoft.WindowsAppSDK 1.6.250205002 → 1.8.260710003, with the workload config's runtime install bumped to `Microsoft.WindowsAppRuntime.1.8` to match
- **winui + winforms workloads**: Visual Studio Community pin 18.4.3 → 18.8.2

### Workflows
- `actions/checkout` and `actions/upload-artifact` updated to v7.0.1 in `ci.yml`; `signed-copy-guard.yml` now SHA-pinned the same way (was floating `@v4`)

Already current, left alone: Microsoft.VSCode.Dsc 0.1.6-alpha, Cascadia Code 2407.24.

## New: workload undo script — `src/Workloads/undo.ps1`

```powershell
pwsh -File src/Workloads/undo.ps1 -Workload <id|all> [-IncludeShared] [-WhatIf]
```

Best-effort reversal of each `configuration.winget`: undoes script extras first (global `typescript`, `rustup self uninstall`, VS Code extensions, PSScriptAnalyzer settings, VS `setup.exe modify --remove`), then uninstalls the winget packages. Components shared across workloads (PowerShell 7, VS Code, .NET SDK 10, Visual Studio, the VSCode.Dsc module) are kept unless `-IncludeShared` is passed. Skips anything not installed; exits 1 if any step fails.

## Validation
- `src/tests/dotnet`, `winforms`, `winui` hello projects all build clean on .NET SDK 10.0.302 with the new versions
- YamlDotNet 18 verified to produce byte-identical JSON output to 16.2.1 for the repo's untyped deserialize → JsonCompatible serialize pattern
- All edited YAML parses; `undo.ps1` parse-checked and `-WhatIf` dry-runs verified for single and `all` workloads
- QuickWingetSetup itself can't compile in this environment (no Windows SDK kit installed — pre-existing failure, identical on the old versions)